### PR TITLE
Allow setting sentry sample rates via env to avoid spamming beyond sentry license

### DIFF
--- a/asimap/__init__.py
+++ b/asimap/__init__.py
@@ -2,5 +2,5 @@
 Apricot Systematic IMAP server
 """
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __authors__ = ["Scanner Luce <scanner@apricot.com>"]

--- a/asimap/server.py
+++ b/asimap/server.py
@@ -268,17 +268,23 @@ class IMAPServer:
         until server exits.
         """
         if "SENTRY_DSN" in os.environ:
+            traces_sample_rate = float(
+                os.environ.get("SENTRY_TRACES_SAMPLE_RATE", 0.1)
+            )
+            profiles_sample_rate = float(
+                os.environ.get("SENTRY_PROFILES_SAMPLE_RATE", 0.1)
+            )
             logger.debug("Initializing sentry_sdk")
             sentry_sdk.init(
                 dsn=os.environ["SENTRY_DSN"],
                 # Set traces_sample_rate to 1.0 to capture 100%
                 # of transactions for performance monitoring.
-                traces_sample_rate=1.0,
-                profiles_sample_rate=1.0,
+                traces_sample_rate=traces_sample_rate,
+                profiles_sample_rate=profiles_sample_rate,
                 integrations=[
                     AsyncioIntegration(),
                 ],
-                environment="devel",
+                environment="devel" if self.debug else "production",
             )
 
         self.asyncio_server = await asyncio.start_server(

--- a/asimap/user_server.py
+++ b/asimap/user_server.py
@@ -468,17 +468,23 @@ class IMAPUserServer:
         through the main process. Run until the server exits.
         """
         if "SENTRY_DSN" in os.environ:
+            traces_sample_rate = float(
+                os.environ.get("SENTRY_TRACES_SAMPLE_RATE", 0.1)
+            )
+            profiles_sample_rate = float(
+                os.environ.get("SENTRY_PROFILES_SAMPLE_RATE", 0.1)
+            )
             logger.debug("Initializing sentry_sdk")
             sentry_sdk.init(
                 dsn=os.environ["SENTRY_DSN"],
                 # Set traces_sample_rate to 1.0 to capture 100%
                 # of transactions for performance monitoring.
-                traces_sample_rate=1.0,
-                profiles_sample_rate=1.0,
+                traces_sample_rate=traces_sample_rate,
+                profiles_sample_rate=profiles_sample_rate,
                 integrations=[
                     AsyncioIntegration(),
                 ],
-                environment="devel",
+                environment="devel" if self.debug else "production",
             )
         else:
             logger.debug(


### PR DESCRIPTION
Since we are using a free sentry license we need to be able to throttle the sample rates down so we do not exceed our free license capacity.