### PR TITLE
GH-245-use-tempdir-for-copy-operation

### DIFF
--- a/asimap/test/test_mbox.py
+++ b/asimap/test/test_mbox.py
@@ -951,7 +951,7 @@ async def test_mailbox_copy(mailbox_with_bunch_of_email):
     dst_mbox = await mbox.server.get_mailbox(ARCHIVE)
 
     msg_keys = await mbox.mailbox.akeys()
-    msg_set = sorted(list(random.sample(msg_keys, 5)))
+    msg_set = sorted(list(random.sample(msg_keys, 15)))
 
     src_uids, dst_uids = await mbox.copy(msg_set, dst_mbox)
     assert len(src_uids) == len(dst_uids)


### PR DESCRIPTION
basically copy the files to a temp dir before copying them to the destination. Also update the doctext to reflect that we do not nest read locks on both mailboxes. 

Also only the write operations to the dest folder lock a mailbox for write, so batch that in batches of 10 messages at a time so other parts of the system can still access the destination mailbox. Previously if we were, say, deleting 1,000 messages we would lock the destination mailbox for write until all 1,000 messages were added to it. This should be a bit nicer.

Fixes GH-245