### PR TITLE
GH-281: Log cache status. Catch Unicode errors and log which msg and mbox caused it.

### DIFF
--- a/asimap/__init__.py
+++ b/asimap/__init__.py
@@ -2,5 +2,5 @@
 Apricot Systematic IMAP server
 """
 
-__version__ = "2.0.16"
+__version__ = "2.0.17"
 __authors__ = ["Scanner Luce <scanner@apricot.com>"]

--- a/asimap/generator.py
+++ b/asimap/generator.py
@@ -64,7 +64,7 @@ class TextGenerator(Generator):
         not write them.
         """
         if self._headers:
-            super()._write_headers(msg)
+            super()._write_headers(msg)  # type: ignore
 
     ####################################################################
     #

--- a/asimap/test/test_message_cache.py
+++ b/asimap/test/test_message_cache.py
@@ -16,11 +16,18 @@ def test_message_cache_add(faker, email_factory):
     NUM_MSGS_PER_FOLDER = 100
     NUM_FOLDERS = 10
     msg_cache = MessageCache()
+    # Make sure that the message cache __str__ method works
+    #
+    assert str(msg_cache)
     folders = {}
     for folder in (faker.word() for _ in range(NUM_FOLDERS)):
         folders[folder] = [email_factory() for _ in range(NUM_MSGS_PER_FOLDER)]
         for msg_key, msg in enumerate(folders[folder]):
             msg_cache.add(folder, msg_key, msg)
+
+    # Make sure that the message cache __str__ method works
+    #
+    assert str(msg_cache)
 
     num_msgs = msg_cache.num_msgs
     cur_size = msg_cache.cur_size
@@ -40,6 +47,9 @@ def test_message_cache_add(faker, email_factory):
             num_msgs -= 1
             assert msg_cache.num_msgs == num_msgs
     assert msg_cache.cur_size == 0
+    # Make sure that the message cache __str__ method works
+    #
+    assert str(msg_cache)
 
 
 ####################################################################
@@ -57,15 +67,22 @@ def test_message_cache_expiry(faker, email_factory):
 
     folders = {}
     computed_size = 0
+    number_msgs = 0
+
+    # Create and add enough messages to the message cache to force it to expire
+    # some of the messages.
+    #
     for folder in (faker.word() for _ in range(NUM_FOLDERS)):
         folders[folder] = [email_factory() for _ in range(NUM_MSGS_PER_FOLDER)]
         for msg_key, msg in enumerate(folders[folder]):
             msg_cache.add(folder, msg_key, msg)
             computed_size += len(msg.as_string())
+            number_msgs += 1
 
-    num_msgs = msg_cache.num_msgs
-    cur_size = msg_cache.cur_size
-
-    assert num_msgs == NUM_FOLDERS * NUM_MSGS_PER_FOLDER
-    assert cur_size < computed_size
-    assert cur_size <= MAX_SIZE
+    # All the adds above are guaranteed to cause the cache to purge some
+    # messages. So the number of messages in the cache and size of the cache
+    # must be less than what we added.
+    #
+    assert msg_cache.num_msgs < number_msgs
+    assert msg_cache.cur_size < computed_size
+    assert msg_cache.cur_size <= MAX_SIZE


### PR DESCRIPTION
We were not logging our message cache size periodically.

Also the code to get the message cache size was not working anyways. Make sure `num_msgs` in the message cache is updated properly.

Also log when we can not get the size of a message which message caused the problem.