### PR TITLE
GH-288-better-catch-and-report-taskgroup-exceptions

### DIFF
--- a/asimap/__init__.py
+++ b/asimap/__init__.py
@@ -2,5 +2,5 @@
 Apricot Systematic IMAP server
 """
 
-__version__ = "2.0.19"
+__version__ = "2.0.20"
 __authors__ = ["Scanner Luce <scanner@apricot.com>"]

--- a/asimap/search.py
+++ b/asimap/search.py
@@ -425,9 +425,17 @@ class IMAPSearch(object):
         We have a list of search keys. All of them must be True.
         """
         tasks = []
-        async with asyncio.TaskGroup() as tg:
-            for search_op in self.args["search_key"]:
-                tasks.append(tg.create_task(search_op.match(self.ctx)))
+        try:
+            async with asyncio.TaskGroup() as tg:
+                for search_op in self.args["search_key"]:
+                    tasks.append(tg.create_task(search_op.match(self.ctx)))
+        except* Exception as e:
+            for err in e.exceptions:
+                logger.error(
+                    "Unable to perform search operation: %s", err, exc_info=err
+                )
+            raise
+
         if all(x.result() for x in tasks):
             return True
         return False


### PR DESCRIPTION
Also re-jigger how we check all folders: Use 10 workers and a queue instead of task groups batched in 10 folders.