### PR TITLE
GH-288: read locks are task specific. Remove this assertion. We are confident that the readlock has been acquired

### DIFF
--- a/asimap/__init__.py
+++ b/asimap/__init__.py
@@ -2,5 +2,5 @@
 Apricot Systematic IMAP server
 """
 
-__version__ = "2.0.20"
+__version__ = "2.0.21"
 __authors__ = ["Scanner Luce <scanner@apricot.com>"]

--- a/asimap/search.py
+++ b/asimap/search.py
@@ -136,10 +136,6 @@ class SearchContext(object):
         """
         The message parsed in to a MHMessage object
         """
-        # XXX remove when confident
-        #
-        assert self.mailbox.lock.this_task_has_read_lock()
-
         if self._msg:
             return self._msg
 


### PR DESCRIPTION
basically we had a safety check to make sure no one called ctx.msg() without already having a read lock on a folder.

However, we do "searches" as separate tasks in a task group. These _separate tasks_ do not have the read lock.

Checking all the code we never call ctx.msg() without having a deadlock so we can remove this safety check.

Fixes GH-288