### PR TITLE
GH-297-better-debug-log-messages

### DIFF
--- a/asimap/__init__.py
+++ b/asimap/__init__.py
@@ -2,5 +2,5 @@
 Apricot Systematic IMAP server
 """
 
-__version__ = "2.0.22"
+__version__ = "2.0.23"
 __authors__ = ["Scanner Luce <scanner@apricot.com>"]

--- a/asimap/client.py
+++ b/asimap/client.py
@@ -119,7 +119,21 @@ class BaseClientHandler:
         Arguments:
         - `imap_command`: An instance parse.IMAPClientCommand
         """
-        self.debug_log_cmd(imap_command)
+        if self.mbox:
+            logger.debug(
+                "START: Client: %s, State: '%s', mbox: '%s', IMAP Command: %s",
+                self.client.name,
+                self.state.value,
+                self.mbox.name,
+                imap_command,
+            )
+        else:
+            logger.debug(
+                "START: Client: %s, State: '%s', IMAP Command: %s",
+                self.client.name,
+                self.state.value,
+                imap_command,
+            )
 
         # Since the imap command was properly parsed we know it is a valid
         # command. If it is one we support there will be a method
@@ -197,15 +211,12 @@ class BaseClientHandler:
         finally:
             imap_command.timeout_cm = None
             cmd_duration = time.time() - start_time
-            if cmd_duration >= 0.01:
-                # only bother logging commands that take more than 0.01 seconds
-                #
-                logger.debug(
-                    "Client: %s, IMAP Command '%s' took %.3f seconds",
-                    self.client.name,
-                    imap_command.qstr(),
-                    cmd_duration,
-                )
+            logger.debug(
+                "FINISH: Client: %s, IMAP Command '%s' took %.3f seconds",
+                self.client.name,
+                imap_command.qstr(),
+                cmd_duration,
+            )
 
         # If there was no result from running this command then everything went
         # okay and we send back a final 'OK' to the client for processing this
@@ -232,32 +243,6 @@ class BaseClientHandler:
                 f"{cmd.upper()} command completed\r\n"
             )
             await self.client.push(result)
-
-    ##################################################################
-    #
-    def debug_log_cmd(self, cmd: IMAPClientCommand):
-        """
-        More DRY.. we were basically calling this on every IMAP command
-        so instead going to put it into the base class.
-
-        Arguments:
-        - `cmd`: The IMAP command we are executing
-        """
-        if self.mbox:
-            logger.debug(
-                "client: %s, state: %s, mbox: %s, cmd: %s",
-                self.client.name,
-                self.state.value,
-                self.mbox.name,
-                str(cmd),
-            )
-        else:
-            logger.debug(
-                "client: %s, state: %s, cmd: %s",
-                self.client.name,
-                self.state.value,
-                str(cmd),
-            )
 
     ####################################################################
     #

--- a/asimap/parse.py
+++ b/asimap/parse.py
@@ -372,6 +372,9 @@ class IMAPClientCommand:
         """
         tag = self.tag if self.tag else "*"
         command = "none" if self.command is None else self.command
+        if self.uid_command:
+            return f"{tag} UID {command.upper()}"
+
         return f"{tag} {command.upper()}"
 
     #######################################################################

--- a/asimap/user_server.py
+++ b/asimap/user_server.py
@@ -139,7 +139,7 @@ class IMAPClientProxy:
 
     ####################################################################
     #
-    async def start(self):
+    async def run(self):
         """
         Entry point for the asyncio task for handling the network
         connection from an IMAP client.
@@ -244,7 +244,8 @@ class IMAPClientProxy:
                             "Commands in progress: %d, %s",
                             self.server.commands_in_progress,
                             ", ".join(
-                                x.qstr() for x in self.server.active_commands
+                                f"'{x.qstr()}'"
+                                for x in self.server.active_commands
                             ),
                         )
                 # If our state is "logged_out" after processing the command
@@ -583,7 +584,7 @@ class IMAPUserServer:
             writer,
             trace_enabled=self.trace_enabled,
         )
-        task = asyncio.create_task(client_handler.start(), name=name)
+        task = asyncio.create_task(client_handler.run(), name=name)
         task.add_done_callback(self.client_done)
         self.clients[task] = client_handler
         self.expiry = None

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -88,13 +88,13 @@ sniffio==1.3.1
     #   httpx
 tomli-w==1.0.0
     # via hatch
-tomlkit==0.12.5
+tomlkit==0.13.0
     # via hatch
 trove-classifiers==2024.7.2
     # via hatchling
 userpath==1.9.2
     # via hatch
-uv==0.2.23
+uv==0.2.24
     # via hatch
 virtualenv==20.26.3
     # via hatch

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -292,7 +292,7 @@ rich==13.7.1
     #   hatch
 ruff==0.5.1
     # via -r lint.txt
-sentry-sdk==2.8.0
+sentry-sdk==2.9.0
     # via -r production.txt
 shellingham==1.5.4
     # via
@@ -319,7 +319,7 @@ tomli-w==1.0.0
     # via
     #   -r build.txt
     #   hatch
-tomlkit==0.12.5
+tomlkit==0.13.0
     # via
     #   -r build.txt
     #   hatch
@@ -374,7 +374,7 @@ userpath==1.9.2
     # via
     #   -r build.txt
     #   hatch
-uv==0.2.23
+uv==0.2.24
     # via
     #   -r build.txt
     #   hatch

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -20,7 +20,7 @@ python-dotenv==1.0.1
     # via -r production.in
 python-json-logger==2.0.7
     # via -r production.in
-sentry-sdk==2.8.0
+sentry-sdk==2.9.0
     # via -r production.in
 typing-extensions==4.12.2
     # via aiosqlite


### PR DESCRIPTION
Fixes GH-297

Logs command start and finish. before we were skipping duration to reduce noise, but we need that visibility for now.
Fixes the 'qstr' version of the imap command that was not properly detailing UID commands.
Also updates requirements.
Changes the imap client proxy "start" to "run" ... it is a loop so it runs continually.