### PR TITLE
GH-303: Move task cancel out of close.

### DIFF
--- a/asimap/__init__.py
+++ b/asimap/__init__.py
@@ -2,5 +2,5 @@
 Apricot Systematic IMAP server
 """
 
-__version__ = "2.0.25"
+__version__ = "2.0.26"
 __authors__ = ["Scanner Luce <scanner@apricot.com>"]

--- a/asimap/server.py
+++ b/asimap/server.py
@@ -660,9 +660,6 @@ class IMAPSubprocessInterface:
         Close our connection to the subprocess.
         """
         try:
-            if self.wait_task:
-                self.wait_task.cancel(msg="Closing connection to subprocess")
-                self.wait_task = None
             if self.writer:
                 if not self.writer.is_closing():
                     self.writer.close()
@@ -806,12 +803,18 @@ class IMAPSubprocessInterface:
                         self.writer.close()
                         await self.writer.wait_closed()
                         self.writer = None
+                    if self.wait_task:
+                        self.wait_task.cancel()
+                        self.wait_task = None
                     return False
 
             case "logged_out":
                 if self.writer:
                     await self.close()
                     self.writer = None
+                if self.wait_task:
+                    self.wait_task.cancel()
+                    self.wait_task = None
                 return False
         return True
 


### PR DESCRIPTION
having the wait task cancel inside of close was broken.
The wait task would call close on its way out, and then close the connection to the imap client. But the cancel happened on the close, thus that imap client connection close never happened.

The client was not disconnected, did not know it was unauthenticated.