### PR TITLE
GH-388: Counters for mailboxes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         args: [--config=./pyproject.toml]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.6.4
+    rev: v0.6.5
     hooks:
       - id: ruff
         # NOTE: move before 'isort' and 'black' if --fix is enabled

--- a/asimap/__init__.py
+++ b/asimap/__init__.py
@@ -2,5 +2,5 @@
 Apricot Systematic IMAP server
 """
 
-__version__ = "2.1.13"
+__version__ = "2.1.14"
 __authors__ = ["Scanner Luce <scanner@apricot.com>"]

--- a/asimap/client.py
+++ b/asimap/client.py
@@ -331,9 +331,18 @@ class BaseClientHandler:
         Arguments:
         - `msg`: The message to send to the client in the BYE.
         """
+        mbox_name = None
         if self.mbox:
+            mbox_name = self.mbox.name
             self.mbox.unselected(self.client.name)
             self.mbox = None
+
+        logger.warning(
+            "%s: Mailbox: '%s', Unceremonious BYE: %s",
+            self.name,
+            mbox_name,
+            msg,
+        )
 
         try:
             await self.client.push(f"* BYE {msg}\r\n")

--- a/asimap/client.py
+++ b/asimap/client.py
@@ -687,7 +687,7 @@ class Authenticated(BaseClientHandler):
                             self.select_while_selected_count,
                         )
                         self.select_while_selected_count = 0
-                        self.unceremonious_bye(
+                        await self.unceremonious_bye(
                             "You are SELECT'ing the same mailbox too often."
                         )
                         return
@@ -969,7 +969,9 @@ class Authenticated(BaseClientHandler):
         # reconnect and relearn mailbox state.
         #
         if self.mbox is None:
-            self.unceremonious_bye("Your selected mailbox no longer exists")
+            await self.unceremonious_bye(
+                "Your selected mailbox no longer exists"
+            )
             return
 
         with self.mbox:
@@ -1056,7 +1058,9 @@ class Authenticated(BaseClientHandler):
         # reconnect and relearn mailbox state.
         #
         if self.mbox is None:
-            self.unceremonious_bye("Your selected mailbox no longer exists")
+            await self.unceremonious_bye(
+                "Your selected mailbox no longer exists"
+            )
             return
 
         with self.mbox:
@@ -1101,7 +1105,9 @@ class Authenticated(BaseClientHandler):
         # them reconnect and relearn mailbox state.
         #
         if self.mbox is None:
-            self.unceremonious_bye("Your selected mailbox no longer exists")
+            await self.unceremonious_bye(
+                "Your selected mailbox no longer exists"
+            )
             return
 
         with self.mbox:
@@ -1147,7 +1153,9 @@ class Authenticated(BaseClientHandler):
         # reconnect and relearn mailbox state.
         #
         if self.mbox is None:
-            self.unceremonious_bye("Your selected mailbox no longer exists")
+            await self.unceremonious_bye(
+                "Your selected mailbox no longer exists"
+            )
             return
 
         with self.mbox:
@@ -1170,7 +1178,9 @@ class Authenticated(BaseClientHandler):
                     #
                     self.fetch_while_pending_count += 1
                     if self.fetch_while_pending_count > 3:
-                        self.unceremonious_bye("You have pending EXPUNGEs.")
+                        await self.unceremonious_bye(
+                            "You have pending EXPUNGEs."
+                        )
                         return
                     else:
                         raise No("There are pending EXPUNGEs.")
@@ -1230,7 +1240,9 @@ class Authenticated(BaseClientHandler):
         # reconnect and relearn mailbox state.
         #
         if self.mbox is None:
-            self.unceremonious_bye("Your selected mailbox no longer exists")
+            await self.unceremonious_bye(
+                "Your selected mailbox no longer exists"
+            )
             return
 
         with self.mbox:
@@ -1311,7 +1323,9 @@ class Authenticated(BaseClientHandler):
         # reconnect and relearn mailbox state.
         #
         if self.mbox is None:
-            self.unceremonious_bye("Your selected mailbox no longer exists")
+            await self.unceremonious_bye(
+                "Your selected mailbox no longer exists"
+            )
             return
 
         with self.mbox:

--- a/asimap/mbox.py
+++ b/asimap/mbox.py
@@ -618,7 +618,16 @@ class Mailbox:
         else:
             seq_max = self.num_msgs
 
+        logger.debug(
+            "Mailbox: '%s', from uid: %s, seq_max: %d, msg_set: %s",
+            self.name,
+            from_uids,
+            seq_max,
+            msg_set,
+        )
+
         msgs = sequence_set_to_list(msg_set, seq_max, uid_cmd=from_uids)
+        logger.debug("Mailbox: '%s', msg seq nums: %s", self.name, msgs)
 
         # The msg_set is in UID's and we need to convert that to msg sequence
         # numbers. The list `self.uids` is this mapping. If a UID is NOT in
@@ -637,6 +646,12 @@ class Mailbox:
             msgs = [
                 self.uids.index(uid) + 1 for uid in msgs if uid in self.uids
             ]
+            logger.debug(
+                "Mailbox: '%s', after converting from uids: msg seq nums: %s",
+                self.name,
+                msgs,
+            )
+
         return set(msgs)
 
     ####################################################################
@@ -736,30 +751,30 @@ class Mailbox:
                 # between different IMAP Commands that are allowed to run at
                 # the same time if they do not operate on the same messages.
                 #
-                try:
-                    imap_cmd.msg_set_as_set = self.msg_set_to_msg_seq_set(
-                        imap_cmd.msg_set, imap_cmd.uid_command
-                    )
-                except Bad as e:
-                    # XXX This is a hack for now. We are getting some FETCH
-                    # commands where the msg seq being asked for is clearly a
-                    # UID command, yet the `imap_cmd.uid_command` field appears
-                    # to be Falsem, so quickly retry it and log the
-                    # command. Maybe this is an error in the parser.
-                    #
-                    if not imap_cmd.uid_command:
-                        logger.exception(
-                            "Mailbox: '%s', converting msg set to set. "
-                            "Re-attempging as a UID command: '%s': %s",
-                            self.name,
-                            str(imap_cmd),
-                            e,
-                        )
-                        imap_cmd.msg_set_as_set = self.msg_set_to_msg_seq_set(
-                            imap_cmd.msg_set, True
-                        )
-                    else:
-                        raise
+                # try:
+                imap_cmd.msg_set_as_set = self.msg_set_to_msg_seq_set(
+                    imap_cmd.msg_set, imap_cmd.uid_command
+                )
+                # except Bad as e:
+                #     # XXX This is a hack for now. We are getting some FETCH
+                #     # commands where the msg seq being asked for is clearly a
+                #     # UID command, yet the `imap_cmd.uid_command` field appears
+                #     # to be Falsem, so quickly retry it and log the
+                #     # command. Maybe this is an error in the parser.
+                #     #
+                #     if not imap_cmd.uid_command:
+                #         logger.exception(
+                #             "Mailbox: '%s', converting msg set to set. "
+                #             "Re-attempging as a UID command: '%s': %s",
+                #             self.name,
+                #             str(imap_cmd),
+                #             e,
+                #         )
+                #         imap_cmd.msg_set_as_set = self.msg_set_to_msg_seq_set(
+                #             imap_cmd.msg_set, True
+                #         )
+                #     else:
+                #         raise
 
                 # Block until the new IMAP command would not conflict with any
                 # of the currently executing IMAP commands.
@@ -1083,7 +1098,7 @@ class Mailbox:
             # message keys then there have been no changes to the folder
             # and this resync is done.
             #
-            if msg_keys == self.msg_keys:
+            if msg_keys == self.msg_keys and len(self.uids) == self.num_msgs:
                 self.mtime = start_mtime
                 marked = (
                     True
@@ -1094,9 +1109,11 @@ class Mailbox:
                 await self.commit_to_db()
                 return False
 
-            # If the number of messages in the mailbox is less than the
-            # last recorded number of messages then we treat this as a new
-            # mailbox.
+            # If the number of messages in the mailbox is less than the last
+            # recorded number of messages then we treat this as a new
+            # mailbox. NOTE: Outside of EXPUNGE a mailbox can only grow, so if
+            # the number of messages is fewer than the previous number of
+            # messages it shrunk.
             #
             if len(msg_keys) < self.num_msgs:
                 logger.warning(
@@ -1113,16 +1130,69 @@ class Mailbox:
                 self.sequences = defaultdict(set)
                 self.mtime = start_mtime
 
+            elif len(self.msg_keys) != len(self.uids):
+                # XXX There was something broken in the past where we grew the
+                #     uid list by its whole set instead of just the amount
+                #     being added. So, check if the length of the uid's does
+                #     not match the length of the stored message keys then
+                #     something weird happened. Declare the folder invalid and
+                #     rest its stored info.
+                #
+                if len(self.uids) > len(self.msg_keys):
+                    logger.warning(
+                        "Mailbox: '%s', there are more uid's than msg_keys. "
+                        "num msgs: %d, num uids: %d. Truncating start of uids",
+                        self.name,
+                        len(self.msg_keys),
+                        len(self.uids),
+                    )
+                    self.uids = self.uids[-len(self.msg_keys) :]
+                else:
+                    logger.warning(
+                        "Mailbox: '%s' number of uids does not match the "
+                        "number of mesage keys, num uids: %d, num messages: %d."
+                        " Treating as new mailbox",
+                        self.name,
+                        len(self.uids),
+                        len(msg_keys),
+                    )
+                    self.msg_keys = []
+                    self.uids = []
+                    self.num_msgs = 0
+                    self.num_recent = 0
+                    self.sequences = defaultdict(set)
+                    self.mtime = start_mtime
+
             # If we reach here we know that we have new messages. Find out
             # the lowest numbered new message and consider that message and
             # everything after it a new message.
             #
             new_msg_keys = sorted(set(msg_keys) - set(self.msg_keys))
             num_new_msgs = len(new_msg_keys)
+            logger.debug(
+                "Mailbox: '%s': num new messages: %d, new msg keys: %s",
+                self.name,
+                num_new_msgs,
+                new_msg_keys,
+            )
 
             self.msg_keys.extend(new_msg_keys)
-            self.uids.extend(range(self.next_uid, self.next_uid + num_new_msgs))
-            self.next_uid = self.uids[-1] + 1
+            new_uids = list(range(self.next_uid, self.next_uid + num_new_msgs))
+            logger.debug(
+                "Mailbox: %s, num new uids: %d, new uid's: %s",
+                self.name,
+                len(new_uids),
+                new_uids,
+            )
+            self.uids.extend(new_uids)
+            if self.uids:
+                self.next_uid = self.uids[-1] + 1
+
+            if len(self.uids) != len(self.msg_keys):
+                logger.warning(
+                    "Mailbox '%s', after append of new uid's the counts are off.",
+                    self.name,
+                )
 
             # Determine the sequences for the new messages so we know what
             # FETCH messages to send (and to upate our internal sequences
@@ -1171,15 +1241,14 @@ class Mailbox:
 
             num_recent = len(self.sequences["Recent"])
             num_msgs = len(msg_keys)
-
             logger.info(
                 "Mailbox: '%s', num msgs: %d, num new msgs: %d, "
                 "first new msg: %d, last new msg: %d",
                 self.name,
                 self.num_msgs,
                 len(new_msg_keys),
-                new_msg_keys[0],
-                new_msg_keys[-1],
+                new_msg_keys[0] if new_msg_keys else 0,
+                new_msg_keys[-1] if new_msg_keys else 0,
             )
 
             # RECENT and EXISTS are sent as the rest of a SELECT or EXAMINE
@@ -2022,12 +2091,13 @@ class Mailbox:
                     # folder's state.
                     #
                     log_msg = (
-                        f"fetch: Attempted to look up msg key "
-                        f"{msg_seq_num - 1}, but msgs is only of length {self.num_msgs}"
+                        f"Mailbox '{self.name}': Attempted to look up msg seq "
+                        f"num {msg_seq_num}, but msgs is only of length "
+                        f"{self.num_msgs}"
                     )
                     logger.warning(log_msg)
                     self.optional_resync = False
-                    raise MailboxInconsistency(log_msg)
+                    raise MailboxInconsistency(log_msg, mbox_name=self.name)
 
                 ctx = SearchContext(
                     self, msg_key, msg_seq_num, seq_max, uid_max, self.sequences
@@ -3004,7 +3074,7 @@ async def _helper_rename_folder(mbox: Mailbox, new_name: str):
 
 ####################################################################
 #
-async def _helper_rename_inbox(mbox: Mailbox, new_name: str):
+async def _helper_rename_inbox(inbox: Mailbox, new_name: str):
     """
     When the `inbox` gets renamed what happens is all messages in the inbox
     get moved to the new mailbox (and removed from the inbox.)
@@ -3016,7 +3086,7 @@ async def _helper_rename_inbox(mbox: Mailbox, new_name: str):
     # new mailbox. Inferior mailboxes of 'inbox' are unchanged and not
     # copied.
     #
-    server = mbox.server
+    server = inbox.server
     await Mailbox.create(new_name, server)
 
     # We will get all the keys, fetch them one by one. If they are not there
@@ -3027,41 +3097,43 @@ async def _helper_rename_inbox(mbox: Mailbox, new_name: str):
     #
     async with server.get_mailbox(new_name) as new_mbox:
         uids = []
+        sequences: Sequences = defaultdict(set)
 
-        for key in await mbox.mailbox.akeys():
+        for key in await inbox.mailbox.akeys():
             try:
-                msg = await mbox.mailbox.aget_message(key)
+                msg = await inbox.mailbox.aget_message(key)
+                for seq in inbox.sequences.keys():
+                    if key in inbox.sequences[seq]:
+                        sequences[seq].add(key)
             except KeyError:
                 continue
 
-            # Replace the asimap uid since this is a new folder.
-            #
             uids.append(new_mbox.next_uid)
-            uid = f"{new_mbox.uid_vv:010d}.{new_mbox.next_uid:010d}"
             new_mbox.next_uid += 1
-            del msg["X-asimapd-uid"]
-            msg["X-asimapd-uid"] = uid
             await new_mbox.mailbox.aadd(msg)
             try:
-                await mbox.mailbox.aremove(key)
+                await inbox.mailbox.aremove(key)
             except KeyError:
                 pass
 
         new_mbox.uids = uids
-        new_mbox.sequences = await new_mbox.mailbox.aget_sequences()
+        new_mbox.sequences = sequences
         new_mbox.msg_keys = await new_mbox.mailbox.akeys()
         new_mbox.optional_resync = False
         await new_mbox.commit_to_db()
 
-    mbox.optional_resync = False
-    mbox.sequences = await mbox.mailbox.aget_sequences()
+    inbox.optional_resync = False
 
     # We need to send EXPUNGES to all the other clients
     #
     notifications = []
-    for msg_seq_num in range(len(mbox.msg_keys), 0, -1):
+    for msg_seq_num in range(len(inbox.msg_keys), 0, -1):
         notifications.append(f"* {msg_seq_num} EXPUNGE\r\n")
-    await mbox._dispatch_or_pend_notifications(notifications)
-    mbox.msg_keys = []
-    mbox.uids = []
-    await mbox.commit_to_db()
+    await inbox._dispatch_or_pend_notifications(notifications)
+
+    inbox.sequences = defaultdict(set)
+    inbox.msg_keys = []
+    inbox.num_msgs = 0
+    inbox.uids = []
+    await inbox.mailbox.aset_sequences(inbox.sequences)
+    await inbox.commit_to_db()

--- a/asimap/test/conftest.py
+++ b/asimap/test/conftest.py
@@ -10,6 +10,7 @@ import json
 import ssl
 import threading
 import time
+from contextlib import asynccontextmanager
 from email.header import decode_header
 from email.headerregistry import Address
 from email.message import EmailMessage, Message
@@ -542,11 +543,12 @@ def mailbox_instance(bunch_of_email_in_folder, imap_user_server):
     create a Mailbox which has email in it.
     """
 
+    @asynccontextmanager
     async def create_mailbox(name: str = "inbox", with_messages: bool = False):
         bunch_of_email_in_folder(folder=name)
         server = imap_user_server
-        mbox = await server.get_mailbox(name)
-        return mbox
+        async with server.get_mailbox(name) as mbox:
+            yield mbox
 
     return create_mailbox
 
@@ -623,8 +625,8 @@ async def mailbox_with_big_static_email(
     msg = MHMessage(big_static_email)
     msg.add_sequence("unseen")
     m_folder.add(msg)
-    mbox = await server.get_mailbox(NAME)
-    return mbox
+    async with server.get_mailbox(NAME) as mbox:
+        yield mbox
 
 
 ####################################################################
@@ -644,8 +646,8 @@ async def mailbox_with_mimekit_email(
         msg = MHMessage(msg_text)
         msg.add_sequence("unseen")
         m_folder.add(msg)
-    mbox = await server.get_mailbox(NAME)
-    return mbox
+    async with server.get_mailbox(NAME) as mbox:
+        yield mbox
 
 
 ####################################################################
@@ -665,8 +667,8 @@ async def mailbox_with_problematic_email(
         msg = MHMessage(msg_text)
         msg.add_sequence("unseen")
         m_folder.add(msg)
-    mbox = await server.get_mailbox(NAME)
-    return mbox
+    async with server.get_mailbox(NAME) as mbox:
+        yield mbox
 
 
 ####################################################################
@@ -682,6 +684,5 @@ async def mailbox_with_bunch_of_email(
     NAME = "inbox"
     bunch_of_email_in_folder(folder=NAME)
     server = imap_user_server
-    mbox = await server.get_mailbox(NAME)
-
-    return mbox
+    async with server.get_mailbox(NAME) as mbox:
+        yield mbox

--- a/asimap/test/test_mbox.py
+++ b/asimap/test/test_mbox.py
@@ -39,46 +39,49 @@ async def test_mailbox_init(imap_user_server):
     """
     server = imap_user_server
     NAME = "inbox"
-    mbox = await server.get_mailbox(NAME)
-    assert mbox
-    assert mbox.id
-    assert mbox.last_resync == IsNow(unix_number=True)
+    async with server.get_mailbox(NAME) as mbox:
+        assert mbox
+        assert mbox.id
+        assert mbox.last_resync == IsNow(unix_number=True)
 
-    results = await server.db.fetchone(
-        "select id, uid_vv,attributes,mtime,next_uid,num_msgs,"
-        "num_recent,uids,last_resync,subscribed from mailboxes "
-        "where name=?",
-        (NAME,),
-    )
-    (
-        id,
-        uid_vv,
-        attributes,
-        mtime,
-        next_uid,
-        num_msgs,
-        num_recent,
-        uids,
-        last_resync,
-        subscribed,
-    ) = results
-    assert id == mbox.id
-    assert uid_vv == 1  # 1 because first mailbox in server
-    assert mbox.uid_vv == uid_vv
-    assert sorted(attributes.split(",")) == [r"\HasNoChildren", r"\Unmarked"]
-    assert mbox.mtime == mtime
-    assert mtime == IsNow(unix_number=True)
-    assert next_uid == 1
-    assert mbox.next_uid == next_uid
-    assert num_msgs == 0
-    assert mbox.num_msgs == num_msgs
-    assert num_recent == 0
-    assert mbox.num_recent == num_recent
-    assert uids == ""
-    assert len(mbox.uids) == 0
-    assert mbox.last_resync == last_resync
-    assert bool(subscribed) is False
-    assert mbox.subscribed == bool(subscribed)
+        results = await server.db.fetchone(
+            "select id, uid_vv,attributes,mtime,next_uid,num_msgs,"
+            "num_recent,uids,last_resync,subscribed from mailboxes "
+            "where name=?",
+            (NAME,),
+        )
+        (
+            id,
+            uid_vv,
+            attributes,
+            mtime,
+            next_uid,
+            num_msgs,
+            num_recent,
+            uids,
+            last_resync,
+            subscribed,
+        ) = results
+        assert id == mbox.id
+        assert uid_vv == 1  # 1 because first mailbox in server
+        assert mbox.uid_vv == uid_vv
+        assert sorted(attributes.split(",")) == [
+            r"\HasNoChildren",
+            r"\Unmarked",
+        ]
+        assert mbox.mtime == mtime
+        assert mtime == IsNow(unix_number=True)
+        assert next_uid == 1
+        assert mbox.next_uid == next_uid
+        assert num_msgs == 0
+        assert mbox.num_msgs == num_msgs
+        assert num_recent == 0
+        assert mbox.num_recent == num_recent
+        assert uids == ""
+        assert len(mbox.uids) == 0
+        assert mbox.last_resync == last_resync
+        assert bool(subscribed) is False
+        assert mbox.subscribed == bool(subscribed)
 
 
 ####################################################################
@@ -131,28 +134,28 @@ async def test_mailbox_gets_new_message(
     NAME = "inbox"
     bunch_of_email_in_folder(folder=NAME)
     server = imap_user_server
-    mbox = await server.get_mailbox(NAME)
-    last_resync = mbox.last_resync
+    async with server.get_mailbox(NAME) as mbox:
+        last_resync = mbox.last_resync
 
-    # We need to sleep at least one second for mbox.last_resync to change (we
-    # only consider seconds)
-    #
-    await asyncio.sleep(1)
+        # We need to sleep at least one second for mbox.last_resync to change
+        # (we only consider seconds)
+        #
+        await asyncio.sleep(1)
 
-    # Now add one message to the folder.
-    #
-    bunch_of_email_in_folder(folder=NAME, num_emails=1)
-    msg_keys = await mbox.mailbox.akeys()
+        # Now add one message to the folder.
+        #
+        bunch_of_email_in_folder(folder=NAME, num_emails=1)
+        msg_keys = await mbox.mailbox.akeys()
 
-    await mbox.check_new_msgs_and_flags()
-    assert r"\Marked" in mbox.attributes
-    assert mbox.last_resync > last_resync
-    assert mbox.num_msgs == len(msg_keys)
-    assert len(mbox.sequences["unseen"]) == len(msg_keys)
-    assert mbox.sequences["unseen"] == set(msg_keys)
-    assert mbox.sequences["Recent"] == set(msg_keys)
-    assert len(mbox.sequences["Seen"]) == 0
-    assert len(mbox.msg_keys) == len(mbox.uids)
+        await mbox.check_new_msgs_and_flags()
+        assert r"\Marked" in mbox.attributes
+        assert mbox.last_resync > last_resync
+        assert mbox.num_msgs == len(msg_keys)
+        assert len(mbox.sequences["unseen"]) == len(msg_keys)
+        assert mbox.sequences["unseen"] == set(msg_keys)
+        assert mbox.sequences["Recent"] == set(msg_keys)
+        assert len(mbox.sequences["Seen"]) == 0
+        assert len(mbox.msg_keys) == len(mbox.uids)
 
 
 ####################################################################
@@ -259,53 +262,53 @@ async def test_mbox_expunge_with_client(
     NAME = "inbox"
     bunch_of_email_in_folder(folder=NAME)
     server, imap_client = imap_user_server_and_client
-    mbox = await server.get_mailbox(NAME)
-    mbox.clients[imap_client.cmd_processor.name] = imap_client.cmd_processor
+    async with server.get_mailbox(NAME) as mbox:
+        mbox.clients[imap_client.cmd_processor.name] = imap_client.cmd_processor
 
-    # Mark messages for expunge.
-    #
-    msg_keys = await mbox.mailbox.akeys()
-    num_msgs = len(msg_keys)
-    for i in range(1, num_msgs_to_delete + 1):
-        mbox.sequences["Deleted"].add(msg_keys[i])
+        # Mark messages for expunge.
+        #
+        msg_keys = await mbox.mailbox.akeys()
+        num_msgs = len(msg_keys)
+        for i in range(1, num_msgs_to_delete + 1):
+            mbox.sequences["Deleted"].add(msg_keys[i])
 
-    await mbox.mailbox.aset_sequences(mbox.sequences)
+        await mbox.mailbox.aset_sequences(mbox.sequences)
 
-    imap_client.cmd_processor.idling = True
-    await mbox.expunge()
-    imap_client.cmd_processor.idling = False
+        imap_client.cmd_processor.idling = True
+        await mbox.expunge()
+        imap_client.cmd_processor.idling = False
 
-    results = client_push_responses(imap_client)
-    assert results == [
-        "* 5 EXPUNGE",
-        "* 4 EXPUNGE",
-        "* 3 EXPUNGE",
-        "* 2 EXPUNGE",
-    ]
-    assert mbox.uids == [
-        1,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-        16,
-        17,
-        18,
-        19,
-        20,
-    ]
-    msg_keys = await mbox.mailbox.akeys()
-    assert len(msg_keys) == num_msgs - num_msgs_to_delete
-    assert len(mbox.uids) == len(msg_keys)
-    seqs = await mbox.mailbox.aget_sequences()
-    assert "Deleted" not in seqs
-    assert not mbox.sequences["Deleted"]
+        results = client_push_responses(imap_client)
+        assert results == [
+            "* 5 EXPUNGE",
+            "* 4 EXPUNGE",
+            "* 3 EXPUNGE",
+            "* 2 EXPUNGE",
+        ]
+        assert mbox.uids == [
+            1,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+        ]
+        msg_keys = await mbox.mailbox.akeys()
+        assert len(msg_keys) == num_msgs - num_msgs_to_delete
+        assert len(mbox.uids) == len(msg_keys)
+        seqs = await mbox.mailbox.aget_sequences()
+        assert "Deleted" not in seqs
+        assert not mbox.sequences["Deleted"]
 
 
 ####################################################################
@@ -616,37 +619,37 @@ async def test_mailbox_copy(mailbox_with_bunch_of_email):
     # Let the server discover this folder and incorporate it.
     #
     await mbox.server.find_all_folders()
-    dst_mbox = await mbox.server.get_mailbox(ARCHIVE)
+    async with mbox.server.get_mailbox(ARCHIVE) as dst_mbox:
 
-    msg_keys = await mbox.mailbox.akeys()
-    msg_set = sorted(list(random.sample(msg_keys, 15)))
+        msg_keys = await mbox.mailbox.akeys()
+        msg_set = sorted(list(random.sample(msg_keys, 15)))
 
-    src_uids, dst_uids = await mbox.copy(msg_set, dst_mbox)
-    assert len(src_uids) == len(dst_uids)
-    dst_msg_keys = await dst_mbox.mailbox.akeys()
-    assert len(dst_msg_keys) == len(msg_set)
-    assert dst_msg_keys == await archive_mh.akeys()
+        src_uids, dst_uids = await mbox.copy(msg_set, dst_mbox)
+        assert len(src_uids) == len(dst_uids)
+        dst_msg_keys = await dst_mbox.mailbox.akeys()
+        assert len(dst_msg_keys) == len(msg_set)
+        assert dst_msg_keys == await archive_mh.akeys()
 
-    # in the source mailbox the message keys, message indices, and uid's are
-    # all the same values for the same messages (because this is the initial
-    # population of the mailbox it turns out this way).
-    #
-    assert src_uids == msg_set
+        # in the source mailbox the message keys, message indices, and uid's are
+        # all the same values for the same messages (because this is the initial
+        # population of the mailbox it turns out this way).
+        #
+        assert src_uids == msg_set
 
-    # Compare the messages.
-    #
-    for src_msg_key, src_uid, dst_msg_key, dst_uid in zip(
-        msg_set, src_uids, dst_msg_keys, dst_uids
-    ):
-        src_msg = await mbox.mailbox.aget_message(src_msg_key)
-        dst_msg = await dst_mbox.mailbox.aget_message(dst_msg_key)
+        # Compare the messages.
+        #
+        for src_msg_key, src_uid, dst_msg_key, dst_uid in zip(
+            msg_set, src_uids, dst_msg_keys, dst_uids
+        ):
+            src_msg = await mbox.mailbox.aget_message(src_msg_key)
+            dst_msg = await dst_mbox.mailbox.aget_message(dst_msg_key)
 
-        assert_email_equal(src_msg, dst_msg)
+            assert_email_equal(src_msg, dst_msg)
 
-        _, uid = mbox.get_uid_from_msg(src_msg_key)
-        assert uid == src_uid
-        _, uid = dst_mbox.get_uid_from_msg(dst_msg_key)
-        assert uid == dst_uid
+            _, uid = mbox.get_uid_from_msg(src_msg_key)
+            assert uid == src_uid
+            _, uid = dst_mbox.get_uid_from_msg(dst_msg_key)
+            assert uid == dst_uid
 
 
 ####################################################################
@@ -672,48 +675,48 @@ async def test_mailbox_create_delete(
         await Mailbox.create("1234", server)
 
     await Mailbox.create(ARCHIVE, server)
-    archive = await server.get_mailbox(ARCHIVE)
+    async with server.get_mailbox(ARCHIVE) as archive:
 
-    # You can not create a mailbox if it already exists.
-    #
-    with pytest.raises(MailboxExists):
-        await Mailbox.create(ARCHIVE, server)
+        # You can not create a mailbox if it already exists.
+        #
+        with pytest.raises(MailboxExists):
+            await Mailbox.create(ARCHIVE, server)
 
-    # Create a mailbox in a mailbox..
-    #
-    await Mailbox.create(SUB_FOLDER, server)
+        # Create a mailbox in a mailbox..
+        #
+        await Mailbox.create(SUB_FOLDER, server)
 
-    # You can delete a mailbox that has children (it gets the `\Noselect`
-    # attribute)
-    #
-    await Mailbox.delete(ARCHIVE, server)
-    assert r"\Noselect" in archive.attributes
-
-    # If you try to delete a mailbox with `\Noselect` and it has children
-    # mailboxes, this also fails.
-    #
-    with pytest.raises(InvalidMailbox):
+        # You can delete a mailbox that has children (it gets the `\Noselect`
+        # attribute)
+        #
         await Mailbox.delete(ARCHIVE, server)
+        assert r"\Noselect" in archive.attributes
 
-    # You can not select a `\Noselect` mailbox
-    #
-    with pytest.raises(No):
-        await archive.selected(imap_client_proxy.cmd_processor)
+        # If you try to delete a mailbox with `\Noselect` and it has children
+        # mailboxes, this also fails.
+        #
+        with pytest.raises(InvalidMailbox):
+            await Mailbox.delete(ARCHIVE, server)
 
-    # Trying to create it will remove the `\Noselect` attribute..
-    #
-    await Mailbox.create(ARCHIVE, server)
-    assert r"\Noselect" not in archive.attributes
+        # You can not select a `\Noselect` mailbox
+        #
+        with pytest.raises(No):
+            await archive.selected(imap_client_proxy.cmd_processor)
 
-    # and we will copy some messages into the Archive mailbox just to make sure
-    # we can actually do stuff with it.
-    #
-    msg_keys = await mbox.mailbox.akeys()
-    msg_set = sorted(list(random.sample(msg_keys, 5)))
-    src_uids, dst_uids = await mbox.copy(msg_set, archive)
-    archive_msg_keys = await archive.mailbox.akeys()
-    assert len(dst_uids) == len(archive_msg_keys)
-    assert archive.uids == dst_uids
+        # Trying to create it will remove the `\Noselect` attribute..
+        #
+        await Mailbox.create(ARCHIVE, server)
+        assert r"\Noselect" not in archive.attributes
+
+        # and we will copy some messages into the Archive mailbox just to make
+        # sure we can actually do stuff with it.
+        #
+        msg_keys = await mbox.mailbox.akeys()
+        msg_set = sorted(list(random.sample(msg_keys, 5)))
+        src_uids, dst_uids = await mbox.copy(msg_set, archive)
+        archive_msg_keys = await archive.mailbox.akeys()
+        assert len(dst_uids) == len(archive_msg_keys)
+        assert archive.uids == dst_uids
 
 
 ####################################################################
@@ -739,42 +742,43 @@ async def test_mailbox_rename(
     saved_msg_keys = msg_keys[:]
     await Mailbox.rename("inbox", NEW_MBOX_NAME, server)
 
-    new_mbox = await server.get_mailbox(NEW_MBOX_NAME)
-    new_msg_keys = await new_mbox.mailbox.akeys()
+    async with server.get_mailbox(NEW_MBOX_NAME) as new_mbox:
+        new_msg_keys = await new_mbox.mailbox.akeys()
 
-    assert new_msg_keys == msg_keys
-    assert new_mbox.uids == new_msg_keys
+        assert new_msg_keys == msg_keys
+        assert new_mbox.uids == new_msg_keys
 
-    msg_keys = await inbox.mailbox.akeys()
-    assert not msg_keys
-    assert not inbox.uids
-    assert not inbox.sequences
+        msg_keys = await inbox.mailbox.akeys()
+        assert not msg_keys
+        assert not inbox.uids
+        assert not inbox.sequences
 
-    # Create a new subordinate folder for `new_mbox` so we can make sure the
-    # subfolders are treated right when the mailbox is renamed.
-    #
-    await Mailbox.create(NEW_MBOX_NAME + "/subfolder", server)
+        # Create a new subordinate folder for `new_mbox` so we can make sure
+        # the subfolders are treated right when the mailbox is renamed.
+        #
+        await Mailbox.create(NEW_MBOX_NAME + "/subfolder", server)
 
-    # And now rename our `new_mbox`
-    #
-    NEW_NEW_NAME = "newnew_mbox"
-    await Mailbox.rename(NEW_MBOX_NAME, NEW_NEW_NAME, server)
+        # And now rename our `new_mbox`
+        #
+        NEW_NEW_NAME = "newnew_mbox"
+        await Mailbox.rename(NEW_MBOX_NAME, NEW_NEW_NAME, server)
 
-    folders = await server.mailbox.alist_folders()
-    assert folders == ["inbox", "newnew_mbox", "nope"]
+        folders = await server.mailbox.alist_folders()
+        assert folders == ["inbox", "newnew_mbox", "nope"]
 
-    with pytest.raises(NoSuchMailbox):
-        _ = await server.get_mailbox(NEW_MBOX_NAME)
+        with pytest.raises(NoSuchMailbox):
+            async with server.get_mailbox(NEW_MBOX_NAME):
+                pass
 
-    # When we rename a mailbox it changes the name on the mailbox. the object
-    # remains the same. It should have messages equivalent to the origina inbox
-    # list.
-    #
-    new_new_mbox = await server.get_mailbox("newnew_mbox")
-    assert new_mbox == new_new_mbox
-    nnmsg_keys = await new_new_mbox.mailbox.akeys()
-    assert nnmsg_keys == saved_msg_keys
-    assert nnmsg_keys == new_new_mbox.uids
+        # When we rename a mailbox it changes the name on the mailbox. the
+        # object remains the same. It should have messages equivalent to the
+        # origina inbox list.
+        #
+        async with server.get_mailbox("newnew_mbox") as new_new_mbox:
+            assert new_mbox == new_new_mbox
+            nnmsg_keys = await new_new_mbox.mailbox.akeys()
+            assert nnmsg_keys == saved_msg_keys
+            assert nnmsg_keys == new_new_mbox.uids
 
 
 ####################################################################
@@ -1190,13 +1194,12 @@ async def test_msg_set_to_msg_seq_set(
     """
     NAME = "inbox"
     server = imap_user_server
-    mbox = await server.get_mailbox(NAME)
-
-    # For this test we only need to set 'num_msgs', 'msg_keys', and 'uids' on
-    # the mailbox.
-    #
-    mbox.num_msgs = num_msgs
-    mbox.uids = list(range(1, num_msgs + 1))
-    mbox.msg_keys = list(range(1, num_msgs + 1))
-    msg_set_as_set = mbox.msg_set_to_msg_seq_set(sequence_set, uid_cmd)
-    assert msg_set_as_set == expected
+    async with server.get_mailbox(NAME) as mbox:
+        # For this test we only need to set 'num_msgs', 'msg_keys', and 'uids'
+        # on the mailbox.
+        #
+        mbox.num_msgs = num_msgs
+        mbox.uids = list(range(1, num_msgs + 1))
+        mbox.msg_keys = list(range(1, num_msgs + 1))
+        msg_set_as_set = mbox.msg_set_to_msg_seq_set(sequence_set, uid_cmd)
+        assert msg_set_as_set == expected

--- a/asimap/test/test_search.py
+++ b/asimap/test/test_search.py
@@ -33,32 +33,34 @@ async def test_search_context(mailbox_instance):
     A fairly boring test.. just making sure the SearchContext works as
     expected without any failures.
     """
-    mbox = await mailbox_instance()
-    msg_keys = await mbox.mailbox.akeys()
-    seq_max = len(msg_keys)
-    sequences = await mbox.mailbox.aget_sequences()
-    uid_vv, uid_max = mbox.get_uid_from_msg(msg_keys[-1])
-    assert uid_max
+    async with mailbox_instance() as mbox:
+        msg_keys = await mbox.mailbox.akeys()
+        seq_max = len(msg_keys)
+        sequences = await mbox.mailbox.aget_sequences()
+        uid_vv, uid_max = mbox.get_uid_from_msg(msg_keys[-1])
+        assert uid_max
 
-    for idx, msg_key in enumerate(msg_keys):
-        ctx = SearchContext(mbox, msg_key, idx + 1, seq_max, uid_max, sequences)
-        mhmsg = await mbox.mailbox.aget_message(msg_key)
-        uid_vv, uid = mbox.get_uid_from_msg(msg_key)
-        assert uid == await ctx.uid()
-        ctx._uid = None
-        assert await ctx.internal_date() == IsNow(tz=timezone.utc)
-        assert ctx.msg_key == msg_key
-        assert ctx.seq_max == seq_max
-        assert ctx.uid_max == uid_max
-        assert ctx.msg_number == idx + 1
-        assert ctx.sequences == mhmsg.get_sequences()
-        assert_email_equal(mhmsg, await ctx.msg())
-        assert uid == await ctx.uid()
-        assert uid_vv == await ctx.uid_vv()
-        assert get_msg_size(mhmsg) == await ctx.msg_size()
-        email_msg = await ctx.email_message()
-        assert isinstance(email_msg, EmailMessage)
-        assert_email_equal(mhmsg, email_msg)
+        for idx, msg_key in enumerate(msg_keys):
+            ctx = SearchContext(
+                mbox, msg_key, idx + 1, seq_max, uid_max, sequences
+            )
+            mhmsg = await mbox.mailbox.aget_message(msg_key)
+            uid_vv, uid = mbox.get_uid_from_msg(msg_key)
+            assert uid == await ctx.uid()
+            ctx._uid = None
+            assert await ctx.internal_date() == IsNow(tz=timezone.utc)
+            assert ctx.msg_key == msg_key
+            assert ctx.seq_max == seq_max
+            assert ctx.uid_max == uid_max
+            assert ctx.msg_number == idx + 1
+            assert ctx.sequences == mhmsg.get_sequences()
+            assert_email_equal(mhmsg, await ctx.msg())
+            assert uid == await ctx.uid()
+            assert uid_vv == await ctx.uid_vv()
+            assert get_msg_size(mhmsg) == await ctx.msg_size()
+            email_msg = await ctx.email_message()
+            assert isinstance(email_msg, EmailMessage)
+            assert_email_equal(mhmsg, email_msg)
 
 
 ####################################################################

--- a/asimap/test/test_user_server.py
+++ b/asimap/test/test_user_server.py
@@ -69,6 +69,12 @@ async def test_expire_inactive_folders(
     mbox1.in_use_count += 1
     mbox2.in_use_count += 1
 
+    # Using the mailbox as a context manager increases the in-use count.
+    #
+    with mbox1:
+        assert mbox1.in_use_count == 2
+        assert mbox2.in_use_count == 1
+
     # Select the inbox (so we have one folder with no expiry time at all)
     #
     cmd = IMAPClientCommand("A001 SELECT INBOX\r\n")

--- a/asimap/test/test_utils.py
+++ b/asimap/test/test_utils.py
@@ -19,6 +19,8 @@ from ..exceptions import Bad
 from ..utils import (
     UID_HDR,
     UpgradeableReadWriteLock,
+    compact_sequence,
+    expand_sequence,
     find_header_in_binary_file,
     get_uidvv_uid,
     sequence_set_to_list,
@@ -632,3 +634,23 @@ async def test_update_replace_header_in_binary_file(
         hdrs = msg.get_all(UID_HDR)
         assert len(hdrs) == 1
         assert hdrs[0] == value
+
+
+####################################################################
+#
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        ([1, 3, 4, 5, 6], "1,3-6"),
+        ([1, 2, 3, 4, 5, 6], "1-6"),
+        ([1, 2, 9, 12, 13, 14, 15, 20, 21, 23], "1-2,9,12-15,20-21,23"),
+    ],
+)
+def test_compact_expand_sequences(data, expected):
+    """
+    make sure compaction compacts to expected, and when that is expanded it
+    matches the data.
+    """
+    compact = compact_sequence(data)
+    assert compact == expected
+    assert expand_sequence(compact) == data

--- a/asimap/user_server.py
+++ b/asimap/user_server.py
@@ -524,8 +524,7 @@ class IMAPUserServer:
         # initial folder check has finished.
         #
         # self.initial_folder_scan = True
-        self.initial_folder_scan = False  # XXX I think we can safely turn this
-        #     off.
+        self.initial_folder_scan = False
         self.last_full_check = 0.0
 
         # To give individual client connections a more easily read name then
@@ -844,7 +843,8 @@ class IMAPUserServer:
         # unselected.
         #
         for mbox in self.active_mailboxes.values():
-            mbox.unselected(client.name)
+            if client.name in mbox.clients:
+                mbox.unselected(client.name)
         del self.clients[task]
 
         # If there are no more clients, then set the IMAPUserServer's expiry

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -32,7 +32,7 @@ httpx==0.27.2
     # via hatch
 hyperlink==21.0.0
     # via hatch
-idna==3.8
+idna==3.9
     # via
     #   anyio
     #   httpx
@@ -62,7 +62,7 @@ pathspec==0.12.1
     # via hatchling
 pexpect==4.9.0
     # via hatch
-platformdirs==4.3.1
+platformdirs==4.3.3
     # via
     #   hatch
     #   virtualenv
@@ -74,7 +74,7 @@ pygments==2.18.0
     # via rich
 pyproject-hooks==1.1.0
     # via build
-rich==13.8.0
+rich==13.8.1
     # via hatch
 shellingham==1.5.4
     # via hatch
@@ -86,11 +86,11 @@ tomli-w==1.0.0
     # via hatch
 tomlkit==0.13.2
     # via hatch
-trove-classifiers==2024.7.2
+trove-classifiers==2024.9.12
     # via hatchling
 userpath==1.9.2
     # via hatch
-uv==0.4.7
+uv==0.4.10
     # via hatch
 virtualenv==20.26.4
     # via hatch

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -6,7 +6,7 @@
 #
 aiofiles==24.1.0
     # via -r production.txt
-aioretry==5.0.2
+aioretry==5.0.6
     # via -r production.txt
 aiosqlite==0.20.0
     # via -r production.txt
@@ -111,7 +111,7 @@ identify==2.6.0
     # via
     #   -r lint.txt
     #   pre-commit
-idna==3.8
+idna==3.9
     # via
     #   -r build.txt
     #   anyio
@@ -121,7 +121,7 @@ idna==3.8
     #   trustme
 imapclient==3.0.1
     # via -r development.in
-importlib-metadata==8.4.0
+importlib-metadata==8.5.0
     # via
     #   -r lint.txt
     #   yapf
@@ -203,7 +203,7 @@ pexpect==4.9.0
     #   ipython
 pip-tools==7.4.1
     # via -r lint.txt
-platformdirs==4.3.1
+platformdirs==4.3.3
     # via
     #   -r build.txt
     #   -r lint.txt
@@ -241,7 +241,7 @@ pyproject-hooks==1.1.0
     #   -r lint.txt
     #   build
     #   pip-tools
-pytest==8.3.2
+pytest==8.3.3
     # via
     #   -r development.in
     #   pytest-asyncio
@@ -277,14 +277,14 @@ requests==2.32.3
     # via requests-mock
 requests-mock==1.12.1
     # via -r development.in
-rich==13.8.0
+rich==13.8.1
     # via
     #   -r build.txt
     #   -r development.in
     #   hatch
-ruff==0.6.4
+ruff==0.6.5
     # via -r lint.txt
-sentry-sdk==2.13.0
+sentry-sdk==2.14.0
     # via -r production.txt
 shellingham==1.5.4
     # via
@@ -319,7 +319,7 @@ traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-trove-classifiers==2024.7.2
+trove-classifiers==2024.9.12
     # via
     #   -r build.txt
     #   hatchling
@@ -337,11 +337,11 @@ types-pyopenssl==24.1.0.20240722
     # via
     #   -r lint.txt
     #   types-redis
-types-pytz==2024.1.0.20240417
+types-pytz==2024.2.0.20240913
     # via -r lint.txt
 types-redis==4.6.0.20240903
     # via -r lint.txt
-types-requests==2.32.0.20240907
+types-requests==2.32.0.20240914
     # via -r lint.txt
 types-setuptools==74.1.0.20240907
     # via
@@ -354,7 +354,7 @@ typing-extensions==4.12.2
     #   aiosqlite
     #   mypy
     #   pytest-factoryboy
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   -r lint.txt
     #   -r production.txt
@@ -365,7 +365,7 @@ userpath==1.9.2
     # via
     #   -r build.txt
     #   hatch
-uv==0.4.7
+uv==0.4.10
     # via
     #   -r build.txt
     #   hatch
@@ -383,7 +383,7 @@ wheel==0.44.0
     #   pip-tools
 yapf==0.40.2
     # via -r lint.txt
-zipp==3.20.1
+zipp==3.20.2
     # via
     #   -r lint.txt
     #   importlib-metadata

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -28,7 +28,7 @@ filelock==3.16.0
     # via virtualenv
 identify==2.6.0
     # via pre-commit
-importlib-metadata==8.4.0
+importlib-metadata==8.5.0
     # via yapf
 isort==5.13.2
     # via -r lint.in
@@ -48,7 +48,7 @@ pathspec==0.12.1
     # via black
 pip-tools==7.4.1
     # via -r lint.in
-platformdirs==4.3.1
+platformdirs==4.3.3
     # via
     #   black
     #   virtualenv
@@ -63,7 +63,7 @@ pyproject-hooks==1.1.0
     #   pip-tools
 pyyaml==6.0.2
     # via pre-commit
-ruff==0.6.4
+ruff==0.6.5
     # via -r lint.in
 tomli==2.0.1
     # via yapf
@@ -75,11 +75,11 @@ types-cffi==1.16.0.20240331
     # via types-pyopenssl
 types-pyopenssl==24.1.0.20240722
     # via types-redis
-types-pytz==2024.1.0.20240417
+types-pytz==2024.2.0.20240913
     # via -r lint.in
 types-redis==4.6.0.20240903
     # via -r lint.in
-types-requests==2.32.0.20240907
+types-requests==2.32.0.20240914
     # via -r lint.in
 types-setuptools==74.1.0.20240907
     # via
@@ -87,7 +87,7 @@ types-setuptools==74.1.0.20240907
     #   types-cffi
 typing-extensions==4.12.2
     # via mypy
-urllib3==2.2.2
+urllib3==2.2.3
     # via types-requests
 virtualenv==20.26.4
     # via pre-commit
@@ -95,7 +95,7 @@ wheel==0.44.0
     # via pip-tools
 yapf==0.40.2
     # via -r lint.in
-zipp==3.20.1
+zipp==3.20.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,7 +6,7 @@
 #
 aiofiles==24.1.0
     # via -r production.in
-aioretry==5.0.2
+aioretry==5.0.6
     # via -r production.in
 aiosqlite==0.20.0
     # via -r production.in
@@ -20,9 +20,9 @@ python-dotenv==1.0.1
     # via -r production.in
 python-json-logger==2.0.7
     # via -r production.in
-sentry-sdk==2.13.0
+sentry-sdk==2.14.0
     # via -r production.in
 typing-extensions==4.12.2
     # via aiosqlite
-urllib3==2.2.2
+urllib3==2.2.3
     # via sentry-sdk


### PR DESCRIPTION
Also get rid of the mailbox expiry timer. They will now be expired on the next loop of the user server control loop if their in-use count is 0.

Also fix unceremonious bye's

Also use a more compact form for the uids & msg keys in the sqlite db.

If a mailbox has out of whack uid's truncate them to the messages currently in the inbox.