### PR TITLE
GH-392: be more careful to hold mh lock when writing sequences. Add debugging measure to make sure we are writing correct sequences

### DIFF
--- a/asimap/__init__.py
+++ b/asimap/__init__.py
@@ -2,5 +2,5 @@
 Apricot Systematic IMAP server
 """
 
-__version__ = "2.1.15"
+__version__ = "2.1.16"
 __authors__ = ["Scanner Luce <scanner@apricot.com>"]

--- a/asimap/constants.py
+++ b/asimap/constants.py
@@ -5,6 +5,8 @@
 """
 Various global constants.
 """
+from typing import List, Optional
+
 # Here we set the list of defined system flags (flags that may be set on a
 # message) and the subset of those flags that may not be set by a  user.
 #
@@ -40,7 +42,17 @@ SYSTEM_FLAG_MAP = {
     "Seen": r"\Seen",
 }
 
-REVERSE_SYSTEM_FLAG_MAP = {v: k for k, v in SYSTEM_FLAG_MAP.items()}
+REV_SYSTEM_FLAG_MAP = {v: k for k, v in SYSTEM_FLAG_MAP.items()}
+
+
+####################################################################
+#
+def flags_to_seqs(flags: Optional[List[str]]) -> List[str]:
+    """
+    Converts an array of IMAP flags to MH sequence names.
+    """
+    flags = [] if flags is None else flags
+    return [flag_to_seq(x) for x in flags]
 
 
 ####################################################################
@@ -53,9 +65,7 @@ def flag_to_seq(flag):
     Arguments:
     - `flag`: The IMAP flag we are going to translate.
     """
-    if flag in REVERSE_SYSTEM_FLAG_MAP:
-        return REVERSE_SYSTEM_FLAG_MAP[flag]
-    return flag
+    return REV_SYSTEM_FLAG_MAP[flag] if flag in REV_SYSTEM_FLAG_MAP else flag
 
 
 ####################################################################
@@ -67,6 +77,4 @@ def seq_to_flag(seq):
     Arguments:
     - `seq`: The MH sequence name
     """
-    if seq in SYSTEM_FLAG_MAP:
-        return SYSTEM_FLAG_MAP[seq]
-    return seq
+    return SYSTEM_FLAG_MAP[seq] if seq in SYSTEM_FLAG_MAP else seq

--- a/asimap/search.py
+++ b/asimap/search.py
@@ -135,7 +135,8 @@ class SearchContext(object):
         if self._msg:
             return self._msg
 
-        self._msg = await self.mailbox.mailbox.aget_message(self.msg_key)
+        async with self.mailbox.mh_sequences_lock:
+            self._msg = await self.mailbox.mailbox.aget_message(self.msg_key)
         return self._msg
 
     ####################################################################

--- a/asimap/test/test_fetch.py
+++ b/asimap/test/test_fetch.py
@@ -18,7 +18,7 @@ import pytest
 
 # Project imports
 #
-from ..constants import REVERSE_SYSTEM_FLAG_MAP, SYSTEM_FLAGS
+from ..constants import REV_SYSTEM_FLAG_MAP, SYSTEM_FLAGS
 from ..fetch import STR_TO_FETCH_OP, FetchAtt, FetchOp
 from ..generator import msg_as_string, msg_headers_as_string
 from ..mbox import mbox_msg_path
@@ -279,7 +279,7 @@ async def test_fetch_flags(mailbox_with_bunch_of_email):
             for k in seqs["unseen"]:
                 flags_by_msg[k].append("unseen")
 
-        seqs[REVERSE_SYSTEM_FLAG_MAP[flag]] = msgs_by_flag[flag]
+        seqs[REV_SYSTEM_FLAG_MAP[flag]] = msgs_by_flag[flag]
 
     await mbox.mailbox.aset_sequences(seqs)
 

--- a/asimap/test/test_search.py
+++ b/asimap/test/test_search.py
@@ -18,7 +18,7 @@ from dirty_equals import IsNow
 
 # Project imports
 #
-from ..constants import REVERSE_SYSTEM_FLAG_MAP, SYSTEM_FLAGS
+from ..constants import REV_SYSTEM_FLAG_MAP, SYSTEM_FLAGS
 from ..generator import get_msg_size, msg_as_string
 from ..search import IMAPSearch, SearchContext
 from ..utils import parsedate, utime
@@ -86,7 +86,7 @@ async def test_search_keywords(mailbox_with_bunch_of_email):
             for k in seqs["unseen"]:
                 flags_by_msg[k].append("unseen")
 
-        seqs[REVERSE_SYSTEM_FLAG_MAP[flag]] = sorted(msgs_by_flag[flag])
+        seqs[REV_SYSTEM_FLAG_MAP[flag]] = sorted(msgs_by_flag[flag])
 
     await mbox.mailbox.aset_sequences(seqs)
 
@@ -100,7 +100,7 @@ async def test_search_keywords(mailbox_with_bunch_of_email):
                 matches_by_flag[keyword].append(msg_key)
 
     for flag, msg_keys in matches_by_flag.items():
-        assert seqs[REVERSE_SYSTEM_FLAG_MAP[flag]] == sorted(msg_keys)
+        assert seqs[REV_SYSTEM_FLAG_MAP[flag]] == sorted(msg_keys)
 
 
 ####################################################################

--- a/asimap/utils.py
+++ b/asimap/utils.py
@@ -78,6 +78,7 @@ DEFAULT_LOG_CONFIG_FILES = [
 LOGGED_IN_USER: Optional[str] = None
 # REMOTE_ADDRESS:Optional[str] = None
 
+
 ####################################################################
 #
 # Provide os.utime as an asyncio function via aiosfiles `wrap` async decorator


### PR DESCRIPTION
Trying to find out how some of our .mh_sequences got polluted with `\Seen` and hopefully deal with the case where it looks like multiple tasks were writing the .mh_sequences at the same time.
