### PR TITLE
GH-832: Deal with resync recording mailbox shrunk unexpectedly after expunge

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         args: [--config=./pyproject.toml]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.6.7
+    rev: v0.6.8
     hooks:
       - id: ruff
         # NOTE: move before 'isort' and 'black' if --fix is enabled

--- a/asimap/__init__.py
+++ b/asimap/__init__.py
@@ -2,5 +2,5 @@
 Apricot Systematic IMAP server
 """
 
-__version__ = "2.1.17"
+__version__ = "2.1.18"
 __authors__ = ["Scanner Luce <scanner@apricot.com>"]

--- a/asimap/mbox.py
+++ b/asimap/mbox.py
@@ -1538,10 +1538,7 @@ class Mailbox:
                 name, sequence = row
                 sequence = sequence.strip()
                 if sequence:
-                    self.sequences[name] = set(
-                        # int(x) for x in sequence.split(",")
-                        expand_sequence(sequence)
-                    )
+                    self.sequences[name] = set(expand_sequence(sequence))
 
         return False
 
@@ -1924,7 +1921,7 @@ class Mailbox:
             for msg_key in to_delete:
                 self.sequences[seq].discard(msg_key)
         self.num_recent = len(self.sequences["Recent"])
-
+        await self.commit_to_db()
         self.optional_resync = False
 
     ##################################################################
@@ -2080,7 +2077,6 @@ class Mailbox:
                         f"{self.num_msgs}"
                     )
                     logger.warning(log_msg)
-                    self.optional_resync = False
                     raise MailboxInconsistency(log_msg, mbox_name=self.name)
 
                 ctx = SearchContext(

--- a/asimap/user_server.py
+++ b/asimap/user_server.py
@@ -1044,7 +1044,11 @@ class IMAPUserServer:
                 # If the in-use count is positive or the mbox has clients,
                 # do not expire it.
                 #
-                if mbox.in_use_count > 0 or mbox.clients:
+                if (
+                    mbox.in_use_count > 0
+                    or mbox.clients
+                    or mbox.executing_tasks
+                ):
                     continue
                 expired.append(mbox_name)
                 expired_mboxes.append(mbox)

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -41,7 +41,7 @@ jaraco-classes==3.4.0
     # via keyring
 jaraco-context==6.0.1
     # via keyring
-jaraco-functools==4.0.2
+jaraco-functools==4.1.0
     # via keyring
 keyring==25.4.1
     # via hatch
@@ -72,7 +72,7 @@ ptyprocess==0.7.0
     # via pexpect
 pygments==2.18.0
     # via rich
-pyproject-hooks==1.1.0
+pyproject-hooks==1.2.0
     # via build
 rich==13.8.1
     # via hatch
@@ -90,9 +90,9 @@ trove-classifiers==2024.9.12
     # via hatchling
 userpath==1.9.2
     # via hatch
-uv==0.4.16
+uv==0.4.17
     # via hatch
-virtualenv==20.26.5
+virtualenv==20.26.6
     # via hatch
 zstandard==0.23.0
     # via hatch

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -78,7 +78,7 @@ executing==2.1.0
     # via stack-data
 factory-boy==3.3.1
     # via pytest-factoryboy
-faker==29.0.0
+faker==30.0.0
     # via factory-boy
 filelock==3.16.1
     # via
@@ -141,7 +141,7 @@ jaraco-context==6.0.1
     # via
     #   -r build.txt
     #   keyring
-jaraco-functools==4.0.2
+jaraco-functools==4.1.0
     # via
     #   -r build.txt
     #   keyring
@@ -218,7 +218,7 @@ pluggy==1.5.0
     #   pytest
 pre-commit==3.8.0
     # via -r lint.txt
-prompt-toolkit==3.0.47
+prompt-toolkit==3.0.48
     # via ipython
 ptyprocess==0.7.0
     # via
@@ -235,7 +235,7 @@ pygments==2.18.0
     #   -r build.txt
     #   ipython
     #   rich
-pyproject-hooks==1.1.0
+pyproject-hooks==1.2.0
     # via
     #   -r build.txt
     #   -r lint.txt
@@ -282,7 +282,7 @@ rich==13.8.1
     #   -r build.txt
     #   -r development.in
     #   hatch
-ruff==0.6.7
+ruff==0.6.8
     # via -r lint.txt
 sentry-sdk==2.14.0
     # via -r production.txt
@@ -365,11 +365,11 @@ userpath==1.9.2
     # via
     #   -r build.txt
     #   hatch
-uv==0.4.16
+uv==0.4.17
     # via
     #   -r build.txt
     #   hatch
-virtualenv==20.26.5
+virtualenv==20.26.6
     # via
     #   -r build.txt
     #   -r lint.txt

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -57,13 +57,13 @@ pre-commit==3.8.0
     # via -r lint.in
 pycparser==2.22
     # via cffi
-pyproject-hooks==1.1.0
+pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
 pyyaml==6.0.2
     # via pre-commit
-ruff==0.6.7
+ruff==0.6.8
     # via -r lint.in
 tomli==2.0.1
     # via yapf
@@ -89,7 +89,7 @@ typing-extensions==4.12.2
     # via mypy
 urllib3==2.2.3
     # via types-requests
-virtualenv==20.26.5
+virtualenv==20.26.6
     # via pre-commit
 wheel==0.44.0
     # via pip-tools


### PR DESCRIPTION
When "moving" messages in apple mail client we are seeing instances where the mailbox the messages are being moved from is getting the error that during a resync the number of messages was lower than it should.

We should have lowered the message count during the expunge but apparently it was not recorded.
