### PR TITLE
Quick fix to permit an empty root folder

### DIFF
--- a/asimap/__init__.py
+++ b/asimap/__init__.py
@@ -2,5 +2,5 @@
 Apricot Systematic IMAP server
 """
 
-__version__ = "2.1.22"
+__version__ = "2.1.23"
 __authors__ = ["Scanner Luce <scanner@apricot.com>"]

--- a/asimap/test/test_user_server.py
+++ b/asimap/test/test_user_server.py
@@ -13,7 +13,7 @@ import pytest
 # Project imports
 #
 from ..client import Authenticated
-from ..mbox import Mailbox, NoSuchMailbox
+from ..mbox import Mailbox
 from ..parse import IMAPClientCommand
 from ..user_server import IMAPUserServer
 
@@ -159,11 +159,11 @@ async def test_check_folder(
 ####################################################################
 #
 @pytest.mark.asyncio
-async def test_there_is_no_root_folder(imap_user_server):
+async def test_there_is_a_root_folder(imap_user_server):
     server = imap_user_server
-    with pytest.raises(NoSuchMailbox):
-        async with server.get_mailbox(""):
-            pass
+    # with pytest.raises(NoSuchMailbox):
+    async with server.get_mailbox(""):
+        pass
 
 
 ####################################################################

--- a/asimap/user_server.py
+++ b/asimap/user_server.py
@@ -961,7 +961,8 @@ class IMAPUserServer:
         if name.lower() == "inbox":
             name = "inbox"
 
-        if not name.strip() or not self.folder_exists(name):
+        # if not name.strip() or not self.folder_exists(name):
+        if not self.folder_exists(name):
             raise NoSuchMailbox(f"No such mailbox: '{name}'")
 
         # If the mailbox is active we can return it immediately. If not then,


### PR DESCRIPTION
See if this works around iOS 18 Mail app will not connect problems.

Basically with iOS18 the Mail client will connect, do some work, get some information, and then disconnect.
The mail app responds cryptically with the useless error message "IMAP server stopped responding" (which is patently untrue.)

Around the net talk about setting the IMAP prefix fixes the problem and thus it might be related to our removal of an empty root mailbox.