### PR TITLE
GH-382: Related / fall out - resolved the problem by basically making all folders active (in memory)

### DIFF
--- a/asimap/__init__.py
+++ b/asimap/__init__.py
@@ -2,5 +2,5 @@
 Apricot Systematic IMAP server
 """
 
-__version__ = "2.1.23"
+__version__ = "2.1.24"
 __authors__ = ["Scanner Luce <scanner@apricot.com>"]

--- a/asimap/mbox.py
+++ b/asimap/mbox.py
@@ -1752,8 +1752,6 @@ class Mailbox:
         instance and it will check to see if this folder has any children and
         update the attributes as appropriate.
 
-        XXX The biggest downside is that we use MH.list_folders() and I
-            have a feeling that this can be slow at times.
         """
         if len(self.mailbox.list_folders()) > 0:
             self.attributes.add(r"\HasChildren")
@@ -2811,11 +2809,19 @@ class Mailbox:
         #       is annoying. I will just create the intermediary directories.
         #
         mbox_chain: List[str] = []
+        mbox_names: List[str] = []
         for chain_name in name.split("/"):
             mbox_chain.append(chain_name)
             mbox_name = "/".join(mbox_chain)
             MH(server.maildir / mbox_name)
-            mbox = await server.get_mailbox(name)
+            mbox_names.append(mbox_name)
+
+        # Now that we have created all the folders we need to go through them
+        # again from the top to the bottom and see if they have any children.
+        #
+        mbox_names.reverse()
+        for mbox_name in mbox_names:
+            mbox = await server.get_mailbox(mbox_name)
             mbox.check_set_haschildren_attr()
             await mbox.commit_to_db()
 

--- a/asimap/mbox.py
+++ b/asimap/mbox.py
@@ -743,7 +743,7 @@ class Mailbox:
                 # for new messages in this folder. How long we wait until we
                 # timeout depends on whether or not any clients have this
                 # mailbox selected. 1s to 5s if their are any
-                # clients. Otherwise 50s-70s if there are no clients.
+                # clients. Otherwise 10s-20s if there are no clients.
                 #
                 timeout = randrange(1, 5) if self.clients else randrange(10, 20)
                 try:

--- a/asimap/test/conftest.py
+++ b/asimap/test/conftest.py
@@ -9,7 +9,6 @@ import imaplib
 import ssl
 import threading
 import time
-from contextlib import asynccontextmanager
 from email import message_from_bytes
 from email.header import decode_header
 from email.headerregistry import Address
@@ -588,12 +587,11 @@ def mailbox_instance(bunch_of_email_in_folder, imap_user_server):
     create a Mailbox which has email in it.
     """
 
-    @asynccontextmanager
     async def create_mailbox(name: str = "inbox", with_messages: bool = False):
         bunch_of_email_in_folder(folder=name)
         server = imap_user_server
-        async with server.get_mailbox(name) as mbox:
-            yield mbox
+        mbox = await server.get_mailbox(name)
+        return mbox
 
     return create_mailbox
 
@@ -674,8 +672,8 @@ async def mailbox_with_big_static_email(
     seqs = m_folder.get_sequences()
     seqs["unseen"] = [msg_key]
     m_folder.set_sequences(seqs)
-    async with server.get_mailbox(NAME) as mbox:
-        yield mbox
+    mbox = await server.get_mailbox(NAME)
+    return mbox
 
 
 ####################################################################
@@ -699,8 +697,8 @@ async def mailbox_with_mimekit_email(
     seqs = m_folder.get_sequences()
     seqs["unseen"] = STATIC_EMAIL_MSG_KEYS
     m_folder.set_sequences(seqs)
-    async with server.get_mailbox(NAME) as mbox:
-        yield mbox
+    mbox = await server.get_mailbox(NAME)
+    return mbox
 
 
 ####################################################################
@@ -724,8 +722,8 @@ async def mailbox_with_problematic_email(
     seqs = m_folder.get_sequences()
     seqs["unseen"] = STATIC_EMAIL_MSG_KEYS
     m_folder.set_sequences(seqs)
-    async with server.get_mailbox(NAME) as mbox:
-        yield mbox
+    mbox = await server.get_mailbox(NAME)
+    return mbox
 
 
 ####################################################################
@@ -741,5 +739,5 @@ async def mailbox_with_bunch_of_email(
     NAME = "inbox"
     bunch_of_email_in_folder(folder=NAME)
     server = imap_user_server
-    async with server.get_mailbox(NAME) as mbox:
-        yield mbox
+    mbox = await server.get_mailbox(NAME)
+    return mbox

--- a/asimap/test/test_client.py
+++ b/asimap/test/test_client.py
@@ -269,11 +269,11 @@ async def test_authenticated_client_handler_commands(
     assert client_handler.state == ClientState.SELECTED
     assert client_handler.mbox
     assert client_handler.mbox.name == "inbox"
-    async with server.get_mailbox("foo") as mbox_foo:
-        assert mbox_foo
+    mbox_foo = await server.get_mailbox("foo")
+    assert mbox_foo
 
-    async with server.get_mailbox("inbox_copy") as mbox_inbox_copy:
-        assert mbox_inbox_copy
+    mbox_inbox_copy = await server.get_mailbox("inbox_copy")
+    assert mbox_inbox_copy
 
     # Rename inbox_copy to something else.
     #
@@ -393,8 +393,8 @@ async def test_authenticated_client_subscribe_lsub_unsubscribe(
         await client_handler.command(cmd)
         results = client_push_responses(imap_client)
         assert results == [f"A00{idx} OK SUBSCRIBE command completed"]
-        async with server.get_mailbox(subscribe) as mbox:
-            assert mbox.subscribed
+        mbox = await server.get_mailbox(subscribe)
+        assert mbox.subscribed
 
     cmd = IMAPClientCommand('A001 LSUB "" "*"\r\n')
     cmd.parse()
@@ -415,8 +415,8 @@ async def test_authenticated_client_subscribe_lsub_unsubscribe(
         await client_handler.command(cmd)
         results = client_push_responses(imap_client)
         assert results == [f"A00{idx} OK UNSUBSCRIBE command completed"]
-        async with server.get_mailbox(subscribe) as mbox:
-            assert mbox.subscribed is False
+        mbox = await server.get_mailbox(subscribe)
+        assert mbox.subscribed is False
 
     # and lsub will have no results
     #
@@ -458,34 +458,34 @@ async def test_authenticated_client_append(
 
     # Get the message from the mailbox..
     #
-    async with server.get_mailbox("inbox") as mbox:
-        appended_msg = mbox.get_msg(21)
-        assert_email_equal(msg, appended_msg)
+    mbox = await server.get_mailbox("inbox")
+    appended_msg = mbox.get_msg(21)
+    assert_email_equal(msg, appended_msg)
 
-        # Let us append again, but this time with the mailbox selected. We
-        # should get untagged updates from the mailbox for the new message.
-        #
-        cmd = IMAPClientCommand("A002 SELECT inbox")
-        cmd.parse()
-        await client_handler.command(cmd)
-        results = client_push_responses(imap_client)
-        msg = email_factory()
-        msg_as_string = msg.as_string(policy=SMTP)
+    # Let us append again, but this time with the mailbox selected. We
+    # should get untagged updates from the mailbox for the new message.
+    #
+    cmd = IMAPClientCommand("A002 SELECT inbox")
+    cmd.parse()
+    await client_handler.command(cmd)
+    results = client_push_responses(imap_client)
+    msg = email_factory()
+    msg_as_string = msg.as_string(policy=SMTP)
 
-        cmd = IMAPClientCommand(
-            f'A003 APPEND inbox (\\Flagged) "05-jan-1999 20:55:23 +0000" {{{len(msg_as_string)}+}}\r\n{msg_as_string}'
-        )
-        cmd.parse()
-        await client_handler.command(cmd)
-        results = client_push_responses(imap_client)
-        assert results == [
-            "* 22 EXISTS",
-            "* 22 RECENT",
-            r"* 22 FETCH (FLAGS (\Recent \Flagged \Seen))",
-            "A003 OK [APPENDUID 1 22] APPEND command completed",
-        ]
-        appended_msg = mbox.get_msg(22)
-        assert_email_equal(msg, appended_msg)
+    cmd = IMAPClientCommand(
+        f'A003 APPEND inbox (\\Flagged) "05-jan-1999 20:55:23 +0000" {{{len(msg_as_string)}+}}\r\n{msg_as_string}'
+    )
+    cmd.parse()
+    await client_handler.command(cmd)
+    results = client_push_responses(imap_client)
+    assert results == [
+        "* 22 EXISTS",
+        "* 22 RECENT",
+        r"* 22 FETCH (FLAGS (\Recent \Flagged \Seen))",
+        "A003 OK [APPENDUID 1 22] APPEND command completed",
+    ]
+    appended_msg = mbox.get_msg(22)
+    assert_email_equal(msg, appended_msg)
 
 
 ####################################################################
@@ -535,52 +535,52 @@ async def test_authenticated_client_close(
 
     # Messages that are marked `\Deleted` are removed when the mbox is closed.
     #
-    async with server.get_mailbox("inbox") as mbox:
-        msg_keys = mbox.mailbox.keys()
-        to_delete = sorted(random.sample(msg_keys, 5))
-        await mbox.store(to_delete, StoreAction.ADD_FLAGS, [r"\Deleted"])
+    mbox = await server.get_mailbox("inbox")
+    msg_keys = mbox.mailbox.keys()
+    to_delete = sorted(random.sample(msg_keys, 5))
+    await mbox.store(to_delete, StoreAction.ADD_FLAGS, [r"\Deleted"])
 
-        # Closing when we had done 'EXAMINE' does not result in messages being
-        # purged.
-        #
-        cmd = IMAPClientCommand("A002 EXAMINE INBOX")
-        cmd.parse()
-        await client_handler.command(cmd)
-        client_push_responses(imap_client)
+    # Closing when we had done 'EXAMINE' does not result in messages being
+    # purged.
+    #
+    cmd = IMAPClientCommand("A002 EXAMINE INBOX")
+    cmd.parse()
+    await client_handler.command(cmd)
+    client_push_responses(imap_client)
 
-        cmd = IMAPClientCommand("A003 CLOSE")
-        cmd.parse()
-        await client_handler.command(cmd)
-        results = client_push_responses(imap_client)
-        assert results == ["A003 OK CLOSE command completed"]
-        assert client_handler.mbox is None
-        assert client_handler.name not in mbox.clients
+    cmd = IMAPClientCommand("A003 CLOSE")
+    cmd.parse()
+    await client_handler.command(cmd)
+    results = client_push_responses(imap_client)
+    assert results == ["A003 OK CLOSE command completed"]
+    assert client_handler.mbox is None
+    assert client_handler.name not in mbox.clients
 
-        # And get the message keys again.. should have no changes from the
-        # previous set.
-        #
-        new_msg_keys = mbox.mailbox.keys()
-        assert new_msg_keys == msg_keys
+    # And get the message keys again.. should have no changes from the
+    # previous set.
+    #
+    new_msg_keys = mbox.mailbox.keys()
+    assert new_msg_keys == msg_keys
 
-        # Now SELECT the inbox, and then close it.. the messages we had marked
-        # `\Deleted` should be removed from the mbox.
-        #
-        cmd = IMAPClientCommand("A004 SELECT INBOX")
-        cmd.parse()
-        await client_handler.command(cmd)
-        client_push_responses(imap_client)
+    # Now SELECT the inbox, and then close it.. the messages we had marked
+    # `\Deleted` should be removed from the mbox.
+    #
+    cmd = IMAPClientCommand("A004 SELECT INBOX")
+    cmd.parse()
+    await client_handler.command(cmd)
+    client_push_responses(imap_client)
 
-        cmd = IMAPClientCommand("A005 CLOSE")
-        cmd.parse()
-        await client_handler.command(cmd)
-        results = client_push_responses(imap_client)
-        assert results == ["A005 OK CLOSE command completed"]
-        assert client_handler.mbox is None
-        assert client_handler.name not in mbox.clients
+    cmd = IMAPClientCommand("A005 CLOSE")
+    cmd.parse()
+    await client_handler.command(cmd)
+    results = client_push_responses(imap_client)
+    assert results == ["A005 OK CLOSE command completed"]
+    assert client_handler.mbox is None
+    assert client_handler.name not in mbox.clients
 
-        new_msg_keys = mbox.mailbox.keys()
-        for msg_key in to_delete:
-            assert msg_key not in new_msg_keys
+    new_msg_keys = mbox.mailbox.keys()
+    for msg_key in to_delete:
+        assert msg_key not in new_msg_keys
 
 
 ####################################################################
@@ -601,67 +601,65 @@ async def test_authenticated_client_expunge(
 
     # Messages that are marked `\Deleted` are removed when the mbox is closed.
     #
-    async with server.get_mailbox("inbox") as mbox:
-        msg_keys = mbox.mailbox.keys()
-        to_delete = sorted(random.sample(msg_keys, 5))
-        await mbox.store(to_delete, StoreAction.ADD_FLAGS, [r"\Deleted"])
+    mbox = await server.get_mailbox("inbox")
+    msg_keys = mbox.mailbox.keys()
+    to_delete = sorted(random.sample(msg_keys, 5))
+    await mbox.store(to_delete, StoreAction.ADD_FLAGS, [r"\Deleted"])
 
-        # Expunging when we had done 'EXAMINE' does not result in messages being
-        # purged.
-        #
-        cmd = IMAPClientCommand("A002 EXAMINE INBOX")
-        cmd.parse()
-        await client_handler.command(cmd)
-        client_push_responses(imap_client)
+    # Expunging when we had done 'EXAMINE' does not result in messages being
+    # purged.
+    #
+    cmd = IMAPClientCommand("A002 EXAMINE INBOX")
+    cmd.parse()
+    await client_handler.command(cmd)
+    client_push_responses(imap_client)
 
-        cmd = IMAPClientCommand("A003 EXPUNGE")
-        cmd.parse()
-        await client_handler.command(cmd)
-        results = client_push_responses(imap_client)
-        assert results == ["A003 OK EXPUNGE command completed"]
-        assert client_handler.mbox == mbox
-        assert client_handler.name in mbox.clients
+    cmd = IMAPClientCommand("A003 EXPUNGE")
+    cmd.parse()
+    await client_handler.command(cmd)
+    results = client_push_responses(imap_client)
+    assert results == ["A003 OK EXPUNGE command completed"]
+    assert client_handler.mbox == mbox
+    assert client_handler.name in mbox.clients
 
-        # And get the message keys again.. should have no changes from the
-        # previous set.
-        #
-        new_msg_keys = mbox.mailbox.keys()
-        assert new_msg_keys == msg_keys
+    # And get the message keys again.. should have no changes from the
+    # previous set.
+    #
+    new_msg_keys = mbox.mailbox.keys()
+    assert new_msg_keys == msg_keys
 
-        # Now SELECT the inbox, and then close it.. the messages we had marked
-        # `\Deleted` should be removed from the mbox.
-        #
-        cmd = IMAPClientCommand("A004 SELECT INBOX")
-        cmd.parse()
-        await client_handler.command(cmd)
-        client_push_responses(imap_client)
+    # Now SELECT the inbox, and then close it.. the messages we had marked
+    # `\Deleted` should be removed from the mbox.
+    #
+    cmd = IMAPClientCommand("A004 SELECT INBOX")
+    cmd.parse()
+    await client_handler.command(cmd)
+    client_push_responses(imap_client)
 
-        cmd = IMAPClientCommand("A005 EXPUNGE")
-        cmd.parse()
-        await client_handler.command(cmd)
-        results = client_push_responses(imap_client)
-        # The results should have the same message sequence numbers as
-        # to_delete, in reverse.
-        #
-        for msg, msg_seq_num in zip(
-            results[:-1], sorted(to_delete, reverse=True)
-        ):
-            assert msg == f"* {msg_seq_num} EXPUNGE"
-        # len(results) - 1 for the "OK"
-        #
-        assert len(results) - 1 == len(to_delete)
-        assert results[-1:] == [
-            "A005 OK EXPUNGE command completed",
-        ]
-        for deleted, result in zip(sorted(to_delete, reverse=True), results):
-            assert f"* {deleted} EXPUNGE" == result
+    cmd = IMAPClientCommand("A005 EXPUNGE")
+    cmd.parse()
+    await client_handler.command(cmd)
+    results = client_push_responses(imap_client)
+    # The results should have the same message sequence numbers as
+    # to_delete, in reverse.
+    #
+    for msg, msg_seq_num in zip(results[:-1], sorted(to_delete, reverse=True)):
+        assert msg == f"* {msg_seq_num} EXPUNGE"
+    # len(results) - 1 for the "OK"
+    #
+    assert len(results) - 1 == len(to_delete)
+    assert results[-1:] == [
+        "A005 OK EXPUNGE command completed",
+    ]
+    for deleted, result in zip(sorted(to_delete, reverse=True), results):
+        assert f"* {deleted} EXPUNGE" == result
 
-        assert client_handler.mbox == mbox
-        assert client_handler.name in mbox.clients
+    assert client_handler.mbox == mbox
+    assert client_handler.name in mbox.clients
 
-        new_msg_keys = mbox.mailbox.keys()
-        for msg_key in to_delete:
-            assert msg_key not in new_msg_keys
+    new_msg_keys = mbox.mailbox.keys()
+    for msg_key in to_delete:
+        assert msg_key not in new_msg_keys
 
 
 ####################################################################
@@ -687,8 +685,8 @@ async def test_authenticated_client_search(
     # Every message in the inbox should be unseen.. so our response should have
     # all these message indicies in it.
     #
-    async with server.get_mailbox("inbox") as mbox:
-        msg_keys = mbox.mailbox.keys()
+    mbox = await server.get_mailbox("inbox")
+    msg_keys = mbox.mailbox.keys()
 
     cmd = IMAPClientCommand("A004 SELECT INBOX")
     cmd.parse()
@@ -734,27 +732,26 @@ async def test_authenticated_client_fetch(
     # Every message in the inbox should be unseen.. so our response should have
     # all these message indicies in it.
     #
-    async with server.get_mailbox("inbox") as mbox:
+    mbox = await server.get_mailbox("inbox")
+    cmd = IMAPClientCommand("A004 SELECT INBOX")
+    cmd.parse()
+    await client_handler.command(cmd)
+    client_push_responses(imap_client)
 
-        cmd = IMAPClientCommand("A004 SELECT INBOX")
-        cmd.parse()
-        await client_handler.command(cmd)
-        client_push_responses(imap_client)
-
-        cmd = IMAPClientCommand(
-            "A001 FETCH 1:5 (BODY[HEADER.FIELDS (FROM SUBJECT)])"
-        )
-        cmd.parse()
-        await client_handler.command(cmd)
-        results = client_push_responses(imap_client)
-        assert results[-1] == "A001 OK FETCH command completed"
-        for idx in range(1, 6):
-            msg = mbox.get_msg(idx)
-            inter = [x.strip() for x in results[idx - 1].split("\r\n")]
-            subj = inter[1]
-            frm = inter[2]
-            assert msg["Subject"] == subj.split(":")[1].strip()
-            assert msg["From"] == frm.split(":")[1].strip()
+    cmd = IMAPClientCommand(
+        "A001 FETCH 1:5 (BODY[HEADER.FIELDS (FROM SUBJECT)])"
+    )
+    cmd.parse()
+    await client_handler.command(cmd)
+    results = client_push_responses(imap_client)
+    assert results[-1] == "A001 OK FETCH command completed"
+    for idx in range(1, 6):
+        msg = mbox.get_msg(idx)
+        inter = [x.strip() for x in results[idx - 1].split("\r\n")]
+        subj = inter[1]
+        frm = inter[2]
+        assert msg["Subject"] == subj.split(":")[1].strip()
+        assert msg["From"] == frm.split(":")[1].strip()
 
 
 ####################################################################
@@ -770,8 +767,8 @@ async def test_authenticated_client_fetch_lotta_fields(
     _ = mailbox_with_bunch_of_email
     client_handler = Authenticated(imap_client, server)
 
-    async with server.get_mailbox("inbox") as mbox:
-        msg_keys = mbox.mailbox.keys()
+    mbox = await server.get_mailbox("inbox")
+    msg_keys = mbox.mailbox.keys()
 
     cmd = IMAPClientCommand("A004 SELECT INBOX")
     cmd.parse()
@@ -877,8 +874,8 @@ async def test_authenticated_client_copy(
     results = client_push_responses(imap_client)
     assert results == ["A003 OK [COPYUID 2 2:6 1:5] COPY command completed"]
 
-    async with server.get_mailbox("MEETING") as dst_mbox:
-        msg_keys = dst_mbox.mailbox.keys()
+    dst_mbox = await server.get_mailbox("MEETING")
+    msg_keys = dst_mbox.mailbox.keys()
     assert len(msg_keys) == 5
 
     # Not going to both inspecting the messages.. the `test_mbox` tests should

--- a/asimap/test/test_client.py
+++ b/asimap/test/test_client.py
@@ -330,6 +330,7 @@ async def test_authenticated_client_list(
     cmd.parse()
     await client_handler.command(cmd)
     results = client_push_responses(imap_client)
+
     assert len(results) == len(folders) + 1
     assert results[-1] == "A001 OK LIST command completed"
     for result, folder in zip(results[:-1], folders):
@@ -782,10 +783,6 @@ async def test_authenticated_client_fetch_lotta_fields(
     await client_handler.command(cmd)
     results = client_push_responses(imap_client, strip=False)
     assert results[-1] == "A001 OK FETCH command completed\r\n"
-    for msg_key in msg_keys:
-        res = [x for x in results[msg_key - 1].split("\r\n")]
-        for r in res:
-            print(f"    result: {r}")
 
 
 ####################################################################

--- a/asimap/test/test_search.py
+++ b/asimap/test/test_search.py
@@ -32,28 +32,28 @@ async def test_search_context(mailbox_instance):
     A fairly boring test.. just making sure the SearchContext works as
     expected without any failures.
     """
-    async with mailbox_instance() as mbox:
-        msg_keys = mbox.mailbox.keys()
-        seq_max = len(msg_keys)
-        uid_vv, uid_max = mbox.get_uid_from_msg(msg_keys[-1])
-        assert uid_max
+    mbox = await mailbox_instance()
+    msg_keys = mbox.mailbox.keys()
+    seq_max = len(msg_keys)
+    uid_vv, uid_max = mbox.get_uid_from_msg(msg_keys[-1])
+    assert uid_max
 
-        for idx, msg_key in enumerate(msg_keys):
-            ctx = SearchContext(mbox, msg_key, idx + 1, seq_max, uid_max)
-            msg = mbox.get_msg(msg_key)
-            uid_vv, uid = mbox.get_uid_from_msg(msg_key)
-            assert uid == ctx.uid()
-            ctx._uid = None
-            assert ctx.internal_date() == IsNow(tz=timezone.utc)
-            assert ctx.msg_key == msg_key
-            assert ctx.seq_max == seq_max
-            assert ctx.uid_max == uid_max
-            assert ctx.msg_number == idx + 1
-            assert ctx.sequences == mbox.msg_sequences(msg_key)
-            assert_email_equal(msg, ctx.msg())
-            assert uid == ctx.uid()
-            assert uid_vv == ctx.uid_vv()
-            assert get_msg_size(msg) == ctx.msg_size()
+    for idx, msg_key in enumerate(msg_keys):
+        ctx = SearchContext(mbox, msg_key, idx + 1, seq_max, uid_max)
+        msg = mbox.get_msg(msg_key)
+        uid_vv, uid = mbox.get_uid_from_msg(msg_key)
+        assert uid == ctx.uid()
+        ctx._uid = None
+        assert ctx.internal_date() == IsNow(tz=timezone.utc)
+        assert ctx.msg_key == msg_key
+        assert ctx.seq_max == seq_max
+        assert ctx.uid_max == uid_max
+        assert ctx.msg_number == idx + 1
+        assert ctx.sequences == mbox.msg_sequences(msg_key)
+        assert_email_equal(msg, ctx.msg())
+        assert uid == ctx.uid()
+        assert uid_vv == ctx.uid_vv()
+        assert get_msg_size(msg) == ctx.msg_size()
 
 
 ####################################################################

--- a/asimap/test/test_user_server.py
+++ b/asimap/test/test_user_server.py
@@ -112,20 +112,20 @@ async def test_check_all_folders(
     for _ in range(5):
         folder_name = faker.word()
         await Mailbox.create(folder_name, server)
+        # Make sure folder exists and is active
+        #
+        await server.get_mailbox(folder_name)
         folders.append(folder_name)
+
         for _ in range(3):
             sub_folder = f"{folder_name}/{faker.word()}"
             if sub_folder in folders:
                 continue
             await Mailbox.create(sub_folder, server)
+            # Make sure folder exists and is active
+            #
+            await server.get_mailbox(sub_folder)
             folders.append(sub_folder)
-            _ = await server.get_mailbox(sub_folder)
-
-    # Expire all the mailboxes we made so `check_all_folders` will check them.
-    # (Since there are no clients selecting a mailbox, and all the mailboxes we
-    # created above have their in_use_count==0 they should all get expired.)
-    #
-    await server.expire_inactive_folders()
 
     # select and idle on the inbox
     #

--- a/asimap/test/test_user_server.py
+++ b/asimap/test/test_user_server.py
@@ -33,77 +33,6 @@ async def test_user_server_instantiate(mh_folder):
 ####################################################################
 #
 @pytest.mark.asyncio
-async def test_expire_inactive_folders(
-    faker, mailbox_with_bunch_of_email, imap_user_server_and_client
-):
-    server, imap_client = imap_user_server_and_client
-    _ = mailbox_with_bunch_of_email
-
-    # Let us make several other folders.
-    #
-    folders = ["inbox"]
-    for _ in range(5):
-        folder_name = faker.word()
-        await Mailbox.create(folder_name, server)
-        folders.append(folder_name)
-        for _ in range(3):
-            sub_folder = f"{folder_name}/{faker.word()}"
-            if sub_folder in folders:
-                continue
-            await Mailbox.create(sub_folder, server)
-            async with server.get_mailbox(sub_folder) as sf:
-                assert sf.in_use_count == 1
-                folders.append(sub_folder)
-
-    folders = sorted(folders)
-
-    client_handler = Authenticated(imap_client, server)
-
-    # Expire all the mailboxes we made so `check_all_folders` will check them.
-    #
-    await server.expire_inactive_folders()
-
-    # Get a handle on two mailboxes and increment their in-use count so that
-    # they do not get expired.
-    #
-    async with server.get_mailbox(folders[2]) as mbox1:
-        async with server.get_mailbox(folders[3]) as mbox2:
-
-            # Using the mailbox as a context manager increases the in-use count.
-            #
-            with mbox1:
-                assert mbox1.in_use_count == 2
-                assert mbox2.in_use_count == 1
-
-            # Select the inbox (so we have one folder with no expiry time at
-            # all)
-            #
-            cmd = IMAPClientCommand("A001 SELECT INBOX\r\n")
-            cmd.parse()
-            await client_handler.command(cmd)
-
-            # We should have three active mailboxes now (two protected by async
-            # with clauses and one selected by a client.)
-            #
-            assert len(server.active_mailboxes) == 3
-
-            await server.expire_inactive_folders()
-
-            # and after an expiry check again, still 3 active folders.
-            #
-            assert len(server.active_mailboxes) == 3
-
-        # We have exited mbox2's async with clause which should make it
-        # available for expiry.
-        #
-        await server.expire_inactive_folders()
-        assert len(server.active_mailboxes) == 2
-        assert mbox2.name not in server.active_mailboxes
-
-
-####################################################################
-#
-@pytest.mark.asyncio
 async def test_find_all_folders(
     faker, mailbox_with_bunch_of_email, imap_user_server_and_client
 ):
@@ -161,9 +90,11 @@ async def test_check_folder(
 @pytest.mark.asyncio
 async def test_there_is_a_root_folder(imap_user_server):
     server = imap_user_server
+    # In an attempt to see if the root folder would fix iOS 18's IMAP problems
+    # we allow the root folder to exist. (But it still did not fix iOS 18)
+    #
     # with pytest.raises(NoSuchMailbox):
-    async with server.get_mailbox(""):
-        pass
+    _ = await server.get_mailbox("")
 
 
 ####################################################################
@@ -188,8 +119,7 @@ async def test_check_all_folders(
                 continue
             await Mailbox.create(sub_folder, server)
             folders.append(sub_folder)
-            async with server.get_mailbox(sub_folder):
-                pass
+            _ = await server.get_mailbox(sub_folder)
 
     # Expire all the mailboxes we made so `check_all_folders` will check them.
     # (Since there are no clients selecting a mailbox, and all the mailboxes we

--- a/asimap/user_server.py
+++ b/asimap/user_server.py
@@ -482,14 +482,6 @@ class IMAPUserServer:
         self.activating_mailboxes_lock = asyncio.Lock()
         self.activating_mailboxes: Dict[str, asyncio.Event] = {}
 
-        # In order to avoid a race condition when instantiating a mailbox from
-        # being expired before it is ever marked in use we use this boolean to
-        # tell the `expire_inactive_folders` function to skip doing an expiry
-        # check. If this is a positive integer then we should skip folder
-        # expiry.
-        #
-        self.do_not_run_expiry_now = 0
-
         # A dict of the active IMAP clients that are talking to us.
         #
         # The key is the port number of the attached client.

--- a/asimap/user_server.py
+++ b/asimap/user_server.py
@@ -796,13 +796,6 @@ class IMAPUserServer:
 
         # Scan all the folders and load them in to memory.
         #
-        # XXX Once we get the migration to loading all folders in to memory on
-        #     startup working, we can remove the `initial_folder_scan` and
-        #     rename 'check_all_folders' to be load_and_scan_all_folders()
-        #     since all folders will be in memory at all times we do not need
-        #     to scan them at regular intervals anymore. That will be done by
-        #     each folder's management task.
-        #
         self.initial_folder_scan = True
         await self.check_all_folders()
         self.initial_folder_scan = False


### PR DESCRIPTION
Apparently the in_use_count stuff had holes such that folders were being expired too quickly and sometimes expired, but still active.

A quick fix was to make all folders active, all the time. Turns out this actually has significant memory savings. We are usually never above 30% memory usage for the main email account with over 1,000 folders and 20gb of email.

So decided to go all in: folders are always active once loaded. This will also let us implement support RFC5258 and RFC5189 - LIST command extensions and STATUS information in Extended LIST trivially as the mailboxes are always loaded. This is issue #417.

Before we put off doing these extensions because that would mean loading all the mailboxes whenever a LIST was done, and that would be slow and might as well load them all the time: which we now do.

This fixes GH-382.