### PR TITLE
GH-429: Change the namespace to use the "/" as the prefix character.

### DIFF
--- a/asimap/__init__.py
+++ b/asimap/__init__.py
@@ -2,5 +2,5 @@
 Apricot Systematic IMAP server
 """
 
-__version__ = "2.1.25"
+__version__ = "2.1.26"
 __authors__ = ["Scanner Luce <scanner@apricot.com>"]

--- a/asimap/test/test_mbox.py
+++ b/asimap/test/test_mbox.py
@@ -778,19 +778,19 @@ async def test_mailbox_create_delete(
 ):
     server, imap_client_proxy = imap_user_server_and_client
     mbox = mailbox_with_bunch_of_email
-    ARCHIVE = "Archive"
-    SUB_FOLDER = "Archive/foo"
+    ARCHIVE = "/Archive"
+    SUB_FOLDER = "/Archive/foo"
 
     # Make sure we can not create or delete `inbox` or one that is all digits.
     #
     with pytest.raises(InvalidMailbox):
-        await Mailbox.create("inbox", server)
+        await Mailbox.create("/inbox", server)
 
     with pytest.raises(InvalidMailbox):
-        await Mailbox.delete("inbox", server)
+        await Mailbox.delete("/inbox", server)
 
     with pytest.raises(InvalidMailbox):
-        await Mailbox.create("1234", server)
+        await Mailbox.create("/1234", server)
 
     await Mailbox.create(ARCHIVE, server)
     archive = await server.get_mailbox(ARCHIVE)

--- a/asimap/user_server.py
+++ b/asimap/user_server.py
@@ -911,6 +911,12 @@ class IMAPUserServer:
           and do not take up excess memory in the server. NOTE: As long as a
           mailbox has an active clients, the expiry timer will NOT be active.
         """
+        # If the mailbox name begins with a forward slash strip it off. We
+        # specify `/` as the prefix character in the name space, but do not use
+        # it internally.
+        #
+        name = name[1:] if name and name[0] == "/" else name
+
         # The INBOX is case-insensitive but it is stored in our file system in
         # a case sensitive lower case fashion..
         #

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -90,7 +90,7 @@ trove-classifiers==2024.10.21.16
     # via hatchling
 userpath==1.9.2
     # via hatch
-uv==0.4.29
+uv==0.4.30
     # via hatch
 virtualenv==20.27.1
     # via hatch

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -284,7 +284,7 @@ rich==13.9.4
     #   hatch
 ruff==0.7.2
     # via -r /Users/scanner/src/asimap/requirements/lint.txt
-sentry-sdk==2.17.0
+sentry-sdk==2.18.0
     # via -r /Users/scanner/src/asimap/requirements/production.txt
 shellingham==1.5.4
     # via
@@ -343,7 +343,7 @@ types-redis==4.6.0.20241004
     # via -r /Users/scanner/src/asimap/requirements/lint.txt
 types-requests==2.32.0.20241016
     # via -r /Users/scanner/src/asimap/requirements/lint.txt
-types-setuptools==75.2.0.20241025
+types-setuptools==75.3.0.20241105
     # via
     #   -r /Users/scanner/src/asimap/requirements/lint.txt
     #   types-cffi
@@ -366,7 +366,7 @@ userpath==1.9.2
     # via
     #   -r /Users/scanner/src/asimap/requirements/build.txt
     #   hatch
-uv==0.4.29
+uv==0.4.30
     # via
     #   -r /Users/scanner/src/asimap/requirements/build.txt
     #   hatch

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -81,7 +81,7 @@ types-redis==4.6.0.20241004
     # via -r lint.in
 types-requests==2.32.0.20241016
     # via -r lint.in
-types-setuptools==75.2.0.20241025
+types-setuptools==75.3.0.20241105
     # via
     #   -r lint.in
     #   types-cffi

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -20,7 +20,7 @@ python-dotenv==1.0.1
     # via -r production.in
 python-json-logger==2.0.7
     # via -r production.in
-sentry-sdk==2.17.0
+sentry-sdk==2.18.0
     # via -r production.in
 typing-extensions==4.12.2
     # via aiosqlite


### PR DESCRIPTION
Hints on the net say setting the prefix character to "/" on iOS18 fixes it.. but asimapd had no prefix character, so that should not have matter and the mail client should have understood that (it used to, and does on MacOS Sequoia.)

So taking the long shot that the iOS 18 Mail app does **not** support rootless mailboxes we are going to say that our personal mailboxes have a prefix of "/"

(IF this works will need to remove a bunch of debug logging statements)