### PR TITLE
GH-429: Undo '/' rooted namespace. It does not fix the ios18 Mail client

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         args: [--config=./pyproject.toml]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.7.2
+    rev: v0.7.3
     hooks:
       - id: ruff
         # NOTE: move before 'isort' and 'black' if --fix is enabled

--- a/asimap/__init__.py
+++ b/asimap/__init__.py
@@ -2,5 +2,5 @@
 Apricot Systematic IMAP server
 """
 
-__version__ = "2.1.26"
+__version__ = "2.1.27"
 __authors__ = ["Scanner Luce <scanner@apricot.com>"]

--- a/asimap/test/test_client.py
+++ b/asimap/test/test_client.py
@@ -179,7 +179,8 @@ async def test_preauth_client_handler_login(
     imap_client = await imap_client_proxy()
     client_handler = PreAuthenticated(imap_client)
 
-    cmd = IMAPClientCommand(f"A001 LOGIN {user.username} {password}\r\n")
+    cmd = IMAPClientCommand(f'A001 LOGIN {user.username} "{password}"\r\n')
+    print(f"*** command: '{cmd.input}'")
     cmd.parse()
     await client_handler.command(cmd)
     results = client_push_responses(imap_client)

--- a/asimap/test/test_client.py
+++ b/asimap/test/test_client.py
@@ -180,7 +180,6 @@ async def test_preauth_client_handler_login(
     client_handler = PreAuthenticated(imap_client)
 
     cmd = IMAPClientCommand(f'A001 LOGIN {user.username} "{password}"\r\n')
-    print(f"*** command: '{cmd.input}'")
     cmd.parse()
     await client_handler.command(cmd)
     results = client_push_responses(imap_client)

--- a/asimap/test/test_search.py
+++ b/asimap/test/test_search.py
@@ -461,8 +461,8 @@ async def test_search_larger_smaller(mailbox_with_bunch_of_email):
     sizes = sorted(sizes, key=lambda x: x[0])
     mp = int(len(sizes) / 2)
     mid_size = sizes[mp][0] - 1  # One octet smaller.
-    smaller = sorted([x[1] for x in sizes[:mp]])
-    larger = sorted([x[1] for x in sizes[mp:]])
+    smaller = sorted([x[1] for x in sizes if x[0] < mid_size])
+    larger = sorted([x[1] for x in sizes if x[0] > mid_size])
 
     search_op = IMAPSearch("smaller", n=mid_size)
     for msg_idx, msg_key in enumerate(msg_keys):

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -24,7 +24,7 @@ h11==0.14.0
     # via httpcore
 hatch==1.13.0
     # via -r build.in
-hatchling==1.25.0
+hatchling==1.26.3
     # via hatch
 httpcore==1.0.6
     # via httpx
@@ -53,7 +53,7 @@ more-itertools==10.5.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-packaging==24.1
+packaging==24.2
     # via
     #   build
     #   hatch
@@ -90,7 +90,7 @@ trove-classifiers==2024.10.21.16
     # via hatchling
 userpath==1.9.2
     # via hatch
-uv==0.4.30
+uv==0.5.1
     # via hatch
 virtualenv==20.27.1
     # via hatch

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -78,7 +78,7 @@ executing==2.1.0
     # via stack-data
 factory-boy==3.3.1
     # via pytest-factoryboy
-faker==30.8.2
+faker==32.1.0
     # via factory-boy
 filelock==3.16.1
     # via
@@ -91,7 +91,7 @@ h11==0.14.0
     #   httpcore
 hatch==1.13.0
     # via -r /Users/scanner/src/asimap/requirements/build.txt
-hatchling==1.25.0
+hatchling==1.26.3
     # via
     #   -r /Users/scanner/src/asimap/requirements/build.txt
     #   hatch
@@ -107,7 +107,7 @@ hyperlink==21.0.0
     # via
     #   -r /Users/scanner/src/asimap/requirements/build.txt
     #   hatch
-identify==2.6.1
+identify==2.6.2
     # via
     #   -r /Users/scanner/src/asimap/requirements/lint.txt
     #   pre-commit
@@ -145,7 +145,7 @@ jaraco-functools==4.1.0
     # via
     #   -r /Users/scanner/src/asimap/requirements/build.txt
     #   keyring
-jedi==0.19.1
+jedi==0.19.2
     # via ipython
 keyring==25.5.0
     # via
@@ -177,7 +177,7 @@ nodeenv==1.9.1
     # via
     #   -r /Users/scanner/src/asimap/requirements/lint.txt
     #   pre-commit
-packaging==24.1
+packaging==24.2
     # via
     #   -r /Users/scanner/src/asimap/requirements/build.txt
     #   -r /Users/scanner/src/asimap/requirements/lint.txt
@@ -282,7 +282,7 @@ rich==13.9.4
     #   -r /Users/scanner/src/asimap/requirements/build.txt
     #   -r development.in
     #   hatch
-ruff==0.7.2
+ruff==0.7.3
     # via -r /Users/scanner/src/asimap/requirements/lint.txt
 sentry-sdk==2.18.0
     # via -r /Users/scanner/src/asimap/requirements/production.txt
@@ -303,7 +303,7 @@ stack-data==0.6.3
     # via ipython
 termcolor==2.5.0
     # via pytest-sugar
-tomli==2.0.2
+tomli==2.1.0
     # via
     #   -r /Users/scanner/src/asimap/requirements/lint.txt
     #   yapf
@@ -343,7 +343,7 @@ types-redis==4.6.0.20241004
     # via -r /Users/scanner/src/asimap/requirements/lint.txt
 types-requests==2.32.0.20241016
     # via -r /Users/scanner/src/asimap/requirements/lint.txt
-types-setuptools==75.3.0.20241105
+types-setuptools==75.3.0.20241112
     # via
     #   -r /Users/scanner/src/asimap/requirements/lint.txt
     #   types-cffi
@@ -366,7 +366,7 @@ userpath==1.9.2
     # via
     #   -r /Users/scanner/src/asimap/requirements/build.txt
     #   hatch
-uv==0.4.30
+uv==0.5.1
     # via
     #   -r /Users/scanner/src/asimap/requirements/build.txt
     #   hatch
@@ -378,13 +378,13 @@ virtualenv==20.27.1
     #   pre-commit
 wcwidth==0.2.13
     # via prompt-toolkit
-wheel==0.44.0
+wheel==0.45.0
     # via
     #   -r /Users/scanner/src/asimap/requirements/lint.txt
     #   pip-tools
 yapf==0.40.2
     # via -r /Users/scanner/src/asimap/requirements/lint.txt
-zipp==3.20.2
+zipp==3.21.0
     # via
     #   -r /Users/scanner/src/asimap/requirements/lint.txt
     #   importlib-metadata

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -26,7 +26,7 @@ distlib==0.3.9
     # via virtualenv
 filelock==3.16.1
     # via virtualenv
-identify==2.6.1
+identify==2.6.2
     # via pre-commit
 importlib-metadata==8.5.0
     # via yapf
@@ -40,7 +40,7 @@ mypy-extensions==1.0.0
     #   mypy
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.1
+packaging==24.2
     # via
     #   black
     #   build
@@ -63,9 +63,9 @@ pyproject-hooks==1.2.0
     #   pip-tools
 pyyaml==6.0.2
     # via pre-commit
-ruff==0.7.2
+ruff==0.7.3
     # via -r lint.in
-tomli==2.0.2
+tomli==2.1.0
     # via yapf
 types-aiofiles==24.1.0.20240626
     # via -r lint.in
@@ -81,7 +81,7 @@ types-redis==4.6.0.20241004
     # via -r lint.in
 types-requests==2.32.0.20241016
     # via -r lint.in
-types-setuptools==75.3.0.20241105
+types-setuptools==75.3.0.20241112
     # via
     #   -r lint.in
     #   types-cffi
@@ -91,11 +91,11 @@ urllib3==2.2.3
     # via types-requests
 virtualenv==20.27.1
     # via pre-commit
-wheel==0.44.0
+wheel==0.45.0
     # via pip-tools
 yapf==0.40.2
     # via -r lint.in
-zipp==3.20.2
+zipp==3.21.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Also update requirements